### PR TITLE
Publish helmcharts

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,4 +1,4 @@
-name: Helm Publish
+name: Release Helm Charts
 
 on:
   push:
@@ -6,11 +6,20 @@ on:
       - master
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: J12934/helm-gh-pages-action@master
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: gh-pages
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,16 @@
+name: Helm Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: J12934/helm-gh-pages-action@master
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ keystore.p12
 radar-is.yml
 *.tgz
 production.yaml
+production.yaml.gotmpl
 .idea/
 RADAR-Kubernetes.iml
 postgreskeystore.jks

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ git clone --recurse-submodules https://github.com/RADAR-base/RADAR-Kubernetes.gi
 cd RADAR-Kubernetes
 cp environments.yaml.tmpl environments.yaml
 cp base.yaml production.yaml
+cp base.yaml.gotmpl production.yaml.gotmpl
 vim production.yaml  # Change setup parameters and configurations
+vim production.yaml.gotmpl  # Change setup parameters that require Go templating, such as reading input files
 ./bin/keystore-init
 helmfile sync --concurrency 1
 ```

--- a/base.yaml.gotmpl
+++ b/base.yaml.gotmpl
@@ -1,0 +1,5 @@
+management_portal:
+  # read unencrypted keystore
+  keystore: {{ readFile "etc/keystore.p12" | b64enc | quote }}
+  # read encrypted keystore
+  # {{/* keystore: {{ exec "sops" (list "-d" "etc/keystore.p12") | b64enc | quote }}  */}}

--- a/bin/keystore-init
+++ b/bin/keystore-init
@@ -7,7 +7,8 @@ set -v
 . bin/util.sh
 
 function createKeyStore() {
-  file=$1
+  keystorefile="$1"
+  KEYTOOL_OPTS="-keystore ${keystorefile} -storepass radarbase -keypass radarbase $KEYSTORE_INIT_OPTS"
 
   if ! keytool -list $KEYTOOL_OPTS -alias radarbase-managementportal-ec >/dev/null 2>/dev/null; then
     KEYTOOL_CREATE_OPTS="-genkeypair -alias radarbase-managementportal-ec -keyalg EC -keysize 256 -sigalg SHA256withECDSA -storetype PKCS12 $KEYSTORE_CREATE_OPTS"
@@ -31,54 +32,7 @@ function createKeyStore() {
     echo "--> RSA keypair for signing JWTs already exists. Not creating a new one."
   fi
 
-  chmod 400 "$file"
+  chmod 400 "${keystorefile}"
 }
 
-function convertJksToPkcs12() {
-  src=$1
-  dest=$2
-
-  if [ ! -e $dest ] && [ -e $src ]; then
-    echo "--> Importing PKCS12 key store from existing JKS key store"
-    keytool -importkeystore -srckeystore $src -destkeystore $dest -srcstoretype JKS -deststoretype PKCS12 -deststorepass radarbase -srcstorepass radarbase
-    chmod 400 $dest
-  fi
-}
-
-function writeKeys() {
-  FILE=$1
-  RES=$2
-
-  echo "--> Updating gateway signature keys"
-  echo "resourceName: $RES" > "$FILE"
-  echo "publicKeys:" >> "$FILE"
-
-  ALIASES=($(keytool -list $KEYTOOL_OPTS | grep PrivateKeyEntry | sed -e 's/^\([^,]*\),.*$/\1/'))
-  for (( i=0; i < ${#ALIASES[@]}; i++)); do
-    ALIAS=${ALIASES[$i]}
-    ensure_variable "MANAGEMENTPORTAL_OAUTH_CHECKING_KEY_ALIASES_$i=" $ALIAS .env
-    echo "  - |-" >> "$FILE"
-    if keytool -export $KEYTOOL_OPTS -alias $ALIAS | openssl x509 -inform der -text | grep -q ecdsa-with-SHA256; then
-      REPLACE_PUBKEY="EC PUBLIC KEY"
-    else
-      REPLACE_PUBKEY="PUBLIC KEY"
-    fi
-
-    cert="$(keytool -export $KEYTOOL_OPTS -alias $ALIAS | openssl x509 -inform der -pubkey -noout)"
-    while IFS='' read -r line && [ -n "$line" ]; do
-      line=$(sed "s/PUBLIC KEY/$REPLACE_PUBKEY/" <<< $line)
-      echo "    $line" >> "$FILE"
-    done <<< "$cert"
-  done
-}
-
-keystorefile=charts/management-portal/files/keystore.p12
-oldkeystorefile=etc/managementportal/config/keystore.jks
-
-convertJksToPkcs12 $oldkeystorefile $keystorefile
-
-export KEYTOOL_OPTS="-keystore ${keystorefile} -storepass radarbase -keypass radarbase $KEYSTORE_INIT_OPTS"
-
-createKeyStore "$keystorefile"
-
-writeKeys charts/management-portal/files/radar-is.yml res_RestApi
+createKeyStore etc/keystore.p12

--- a/charts/management-portal/templates/secrets-keystore.yaml
+++ b/charts/management-portal/templates/secrets-keystore.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  keystore.p12: {{ .Values.keystore | quote }}
+  keystore.p12: {{ .Values.keystore }}

--- a/charts/management-portal/templates/secrets-keystore.yaml
+++ b/charts/management-portal/templates/secrets-keystore.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  keystore.p12: {{ .Files.Get "files/keystore.p12" | b64enc | quote }}
+  keystore.p12: {{ .Values.keystore | quote }}

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -53,6 +53,13 @@ tolerations: []
 
 affinity: {}
 
+# B64 encoded Binary keystore file
+# With helmfile, this can be set in a production.yaml.gotmpl
+# file by setting
+#keystore: {{ readFile "keystore.p12" | b64enc | quote }}
+# or with SOPS
+#keystore: {{ exec "sops" (list "-d" "keystore.p12") | b64enc | quote }}
+
 postgres:
   host: postgresql-postgresql
   port: 5432

--- a/environments.yaml.tmpl
+++ b/environments.yaml.tmpl
@@ -2,4 +2,6 @@ environments:
  default:
    values:
    - ../base.yaml
+   - ../base.yaml.gotmpl
    - ../production.yaml
+   - ../production.yaml.gotmpl

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -1,10 +1,7 @@
-environments:
-  default:
-    values:
-    - ../base.yaml
-    - ../../etc/production.yaml
-    secrets:
-    - ../../secrets/production.yaml
+bases:
+- ../environments.yaml
+
+---
 
 helmDefaults:
   timeout: 180


### PR DESCRIPTION
This will publish all helm charts in master branch to GitHub pages. Subsequently, helmfile can use a repository + release instead of needing to include this repository as a directory or Git submodule.