### PR TITLE
Fixes replication for ManagementPortal

### DIFF
--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: multicast
+              containerPort: 5701
           livenessProbe:
             exec:
               command:

--- a/charts/management-portal/templates/hazelcast-service.yaml
+++ b/charts/management-portal/templates/hazelcast-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "management-portal.fullname" . }}-hazelcast
+  labels:
+    app.kubernetes.io/name: {{ include "management-portal.name" . }}-hazelcast
+    helm.sh/chart: {{ include "management-portal.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5701
+      name: hazelcast
+  selector:
+    app.kubernetes.io/name: {{ include "management-portal.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/etc/postgresql/values-production-9.8.9.yaml
+++ b/etc/postgresql/values-production-9.8.9.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.9.0-debian-10-r26
+  tag: 11.9.0-debian-10-r48
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -517,6 +517,12 @@ slave:
   persistence:
     enabled: true
 
+  # Override the resource configuration for slave
+  resources: {}
+  # requests:
+  #   memory: 256Mi
+  #   cpu: 250m
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -651,7 +657,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r207
+    tag: 0.8.0-debian-10-r242
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/etc/postgresql/values.yaml
+++ b/etc/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.9.0-debian-10-r26
+  tag: 11.9.0-debian-10-r48
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,7 +47,7 @@ image:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
-  enabled: true
+  enabled: false
   image:
     registry: docker.io
     repository: bitnami/minideb
@@ -160,7 +160,7 @@ postgresqlDatabase: managementportal
 ## PostgreSQL data dir
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
 ##
-postgresqlDataDir: /bitnami/postgresql
+postgresqlDataDir: /bitnami/postgresql/data
 
 ## An array to add extra environment variables
 ## For example:
@@ -541,6 +541,12 @@ slave:
   persistence:
     enabled: true
 
+  # Override the resource configuration for slave
+  resources: {}
+  # requests:
+  #   memory: 256Mi
+  #   cpu: 250m
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -675,7 +681,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r207
+    tag: 0.8.0-debian-10-r242
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -21,6 +21,8 @@ releases:
       - "../etc/postgresql/values.yaml"
       - {{ .Values.postgresql | toYaml | indent 8 | trim }}
     set:
+      - name: postgresqlPostgresPassword
+        value: {{ .Values.postgres_password }}
       - name: postgresqlPassword
         value: {{ .Values.postgres_password }}
       - name: replication.password

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -14,7 +14,7 @@ repositories:
 releases:
   - name: postgresql
     chart: bitnami/postgresql
-    version: 9.6.0
+    version: 9.8.9
     wait: false
     installed: {{ .Values.postgresql._install }}
     values:


### PR DESCRIPTION
This allows ManagementPortal to run with multiple replicas. Only slight incompatibility is the OAuth client loading, since this deletes all OAuth clients and reconfigures them at every start up. That means that multiple ManagementPortal replicas could potentially overwrite each others OAuth clients.

Includes a fix to work with PostgreSQL recent postgresql charts. This is not backwards compatible with earlier PostgreSQL installations: it changes the data dir. The old data dir no longer works on newly created databases. It also sets the correct postgresql postgres user password on newly created databases.