### PR TITLE
Make gateway more configurable

### DIFF
--- a/charts/radar-gateway/templates/configmap.yaml
+++ b/charts/radar-gateway/templates/configmap.yaml
@@ -18,24 +18,35 @@ data:
     kafka:
       producer:
         bootstrap.servers: {{ .Values.bootstrapServers }}
+        {{- range $key, $value := .Values.producerProperties }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
         {{- if .Values.cc.enabled }}
         security.protocol: SASL_SSL
         sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ .Values.cc.apiKey }}" password="{{ .Values.cc.apiSecret }}";
         ssl.endpoint.identification.algorithm: https
         sasl.mechanism: PLAIN
+        {{- end }}
       admin:
         bootstrap.servers: {{ .Values.bootstrapServers }}
+        {{- range $key, $value := .Values.adminProperties }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- if .Values.cc.enabled }}
         security.protocol: SASL_SSL
         sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ .Values.cc.apiKey }}" password="{{ .Values.cc.apiSecret }}";
         ssl.endpoint.identification.algorithm: https
         sasl.mechanism: PLAIN
-        {{ end }}
+        {{- end }}
       serialization:
         schema.registry.url: {{ .Values.schemaRegistry }}
+        {{- range $key, $value := .Values.serializationProperties }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
         {{- if .Values.cc.enabled }}
         basic.auth.credentials.source: USER_INFO
         schema.registry.basic.auth.user.info: {{ .Values.cc.schemaRegistryApiKey }}:{{ .Values.cc.schemaRegistryApiSecret }}
-        {{ end }}
+        {{- end }}
     auth:
       managementPortalUrl: http://{{ .Values.managementportalHost }}:8080/managementportal
       checkSourceId: {{ .Values.checkSourceId }}

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -65,6 +65,13 @@ max_requests: 1000
 bootstrapServers: kafka-1:9092
 checkSourceId: true
 
+adminProperties: {}
+
+producerProperties: {}
+  compression.type: lz4
+
+serializationProperties: {}
+
 cc:
   enabled: false
   apiKey: ccApikey

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -67,7 +67,7 @@ checkSourceId: true
 
 adminProperties: {}
 
-producerProperties: {}
+producerProperties:
   compression.type: lz4
 
 serializationProperties: {}


### PR DESCRIPTION
Started from the need to enable compression, this allows for more configuration of the Gateway Kafka properties.