### PR TITLE
Moved health check to a separate file 

### DIFF
--- a/charts/management-portal/templates/configmap.yaml
+++ b/charts/management-portal/templates/configmap.yaml
@@ -8,6 +8,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  healthcheck.sh: |
+    #!/bin/sh
+    STATUS=$(wget -O - localhost:8080/managementportal/management/health)
+    if ! (echo "$STATUS" | grep -Fq 'db":{"status":"UP'); then
+      exit 1
+    fi
   oauth_client_details.csv: |
     client_id;resource_ids;client_secret;scope;authorized_grant_types;redirect_uri;authorities;access_token_validity;refresh_token_validity;additional_information;autoapprove
     {{- range $clientId, $client := .Values.oauth_clients -}}

--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -123,8 +123,7 @@ spec:
             exec:
               command:
               - /bin/sh
-              - -c
-              - "wget -O - localhost:8080/managementportal/management/health | grep -v '\"status\": \"DOWN\"'"
+              - /config/healthcheck.sh
             initialDelaySeconds: 60
             periodSeconds: 90
             timeoutSeconds: 5
@@ -134,8 +133,7 @@ spec:
             exec:
               command:
               - /bin/sh
-              - -c
-              - "wget -O - localhost:8080/managementportal/management/health | grep -v '\"status\": \"DOWN\"'"
+              - /config/healthcheck.sh
             initialDelaySeconds: 60
             periodSeconds: 90
             timeoutSeconds: 5


### PR DESCRIPTION
Apparently quotes were being handled properly by Kubernetes so moved the health check to a separate file. 