### PR TITLE
Update radar-gateway resource versions

### DIFF
--- a/charts/radar-gateway/templates/hpa.yaml
+++ b/charts/radar-gateway/templates/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "radar-gateway.fullname" . }}
@@ -11,7 +11,13 @@ spec:
   maxReplicas: 5
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ include "radar-gateway.fullname" . }}
-  targetCPUUtilizationPercentage: 50
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/charts/radar-gateway/templates/ingress.yaml
+++ b/charts/radar-gateway/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "radar-gateway.fullname" . -}}
 {{- $path := .Values.ingress.path -}}
 {{- $hosts := .Values.ingress.hosts -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -30,8 +30,11 @@ spec:
       http:
         paths:
           - path: {{ $path | quote }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -62,7 +62,7 @@ serviceMonitor:
 managementportalHost: management-portal
 schemaRegistry: http://cp-schema-registry:8081
 max_requests: 1000
-bootstrapServers: kafka-1:9092
+bootstrapServers: cp-kafka:9092
 checkSourceId: true
 
 adminProperties: {}


### PR DESCRIPTION
This avoids deprecation messages (ingress) and incompatibility messages (autoscaler). Also fixes default kafka endpoint.