### PR TITLE
Bumped radar-gateway to 0.5.5 and improved health check

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.5.4"
+appVersion: "0.5.5"
 description: A Helm chart for Kubernetes
 name: radar-gateway
-version: 0.1.1
+version: 0.1.2

--- a/charts/radar-gateway/templates/configmap.yaml
+++ b/charts/radar-gateway/templates/configmap.yaml
@@ -8,6 +8,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  healthcheck.sh: |
+     #!/bin/sh
+     STATUS=$(curl -s --max-time 4 localhost:8090/kafka/health)
+     if ! (echo "$STATUS" | grep -Fq '"kafka":{"status":"UP"'); then
+       exit 1
+     fi
   gateway.yml: |
     # Resource config class
     #resourceConfig: org.radarbase.gateway.inject.ManagementPortalEnhancerFactory

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -66,24 +66,20 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /radar-gateway/health
-              port: http
-              httpHeaders:
-                - name: Accept
-                  value: application/json
+            exec:
+              command:
+                - /bin/sh
+                - /etc/radar-gateway/healthcheck.sh
             initialDelaySeconds: 5
             periodSeconds: 90
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /radar-gateway/health
-              port: http
-              httpHeaders:
-                - name: Accept
-                  value: application/json
+            exec:
+              command:
+                - /bin/sh
+                - /etc/radar-gateway/healthcheck.sh
             initialDelaySeconds: 5
             periodSeconds: 90
             timeoutSeconds: 5

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: radarbase/radar-gateway
-  tag: 0.5.4
+  tag: 0.5.5
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
~Pending https://hub.docker.com/repository/registry-1.docker.io/radarbase/radar-gateway/builds/a4779181-fd3f-47f0-8715-045191bb32db.~

Image is available on docker hub.