### PR TITLE
Bump radar-schemas and allow excluding specifications

### DIFF
--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "0.7.0"
 description: A Helm chart for Kubernetes
 name: catalog-server
-version: 0.1.0
+version: 0.2.0

--- a/charts/catalog-server/templates/configmap-java-config.yaml
+++ b/charts/catalog-server/templates/configmap-java-config.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.cc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "catalog-server.fullname" . }}-java-config
+  labels:
+    app: {{ template "catalog-server.name" . }}
+    chart: {{ template "catalog-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  java-config.properties: |
+    # Kafka
+    bootstrap.servers={{ .Values.cc.bootstrapServerurl }}
+    security.protocol=SASL_SSL
+    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ .Values.cc.apiKey }}" password="{{ .Values.cc.apiSecret }}";
+    ssl.endpoint.identification.algorithm=https
+    sasl.mechanism=PLAIN
+{{- end -}}

--- a/charts/catalog-server/templates/configmap.yaml
+++ b/charts/catalog-server/templates/configmap.yaml
@@ -1,19 +1,16 @@
-{{- if .Values.cc.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "catalog-server.fullname" . }}-java-config
+  name: {{ template "catalog-server.fullname" . }}
   labels:
     app: {{ template "catalog-server.name" . }}
     chart: {{ template "catalog-server.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  java-config.properties: |
-    # Kafka
-    bootstrap.servers={{ .Values.cc.bootstrapServerurl }}
-    security.protocol=SASL_SSL
-    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ .Values.cc.apiKey }}" password="{{ .Values.cc.apiSecret }}";
-    ssl.endpoint.identification.algorithm=https
-    sasl.mechanism=PLAIN
-{{- end -}}
+  {{- if .Values.specificationsExclude }}
+  specifications.exclude: |
+    {{- range .Values.specificationsExclude }}
+    {{ . }}
+    {{- end }}
+  {{- end }}

--- a/charts/catalog-server/templates/deployment.yaml
+++ b/charts/catalog-server/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:      
         backup.velero.io/backup-volumes: config
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.cc.enabled }}
+        checksum/configmap-java-config: {{ include (print $.Template.BasePath "/configmap-java-config.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       affinity:
         podAntiAffinity:
@@ -43,9 +47,11 @@ spec:
       initContainers:
       - name: kafka-init
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        args:
+          - topic_init.sh
         env:
-        - name: KAFKA_ZOOKEEPER_CONNECT
-          value: "{{ .Values.zookeeper }}"
+        - name: KAFKA_BOOTSTRAP_SERVERS
+          value: "{{ .Values.kafka }}"
         - name: KAFKA_SCHEMA_REGISTRY
           value: "{{ .Values.schema_registry }}"
         - name: KAFKA_NUM_BROKERS
@@ -55,64 +61,52 @@ spec:
         - name: RADAR_NUM_REPLICATION_FACTOR
           value: "3"
         {{- if .Values.cc.enabled }}
-        - name: CC_CONFIG_FILE_PATH
+        - name: KAFKA_CONFIG_PATH
           value: "/etc/config/java-config.properties"
-        - name: CC_API_KEY
+        - name: SCHEMA_REGISTRY_API_KEY
           valueFrom:
             secretKeyRef:
               name: {{ template "catalog-server.fullname" . }}
               key: srApiKey
-        - name: CC_API_SECRET
+        - name: SCHEMA_REGISTRY_API_SECRET
           valueFrom:
             secretKeyRef:
               name: {{ template "catalog-server.fullname" . }}
               key: srApiSecret
-        command:
-          - "cc_topic_init.sh"
+        {{- end }}
         volumeMounts:
+          - name: config
+            mountPath: /etc/radar-schemas
+          - name: config-schemas
+            mountPath: /schema/conf
+          {{- if .Values.cc.enabled }}
           - name: cc-java-config
             mountPath: /etc/config/
-        {{ end }}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command:
-            - radar-schemas-tools
-            - serve
+          args:
+            - radar-catalog-server
             - /schema/merged
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-          - name: KAFKA_ZOOKEEPER_CONNECT
-            value: "{{ .Values.zookeeper }}"
-          - name: KAFKA_SCHEMA_REGISTRY
-            value: "{{ .Values.schema_registry }}"
-          - name: KAFKA_NUM_BROKERS
-            value: "{{ .Values.kafka_num_brokers }}"
-          - name: RADAR_NUM_PARTITIONS
-            value: "3"
-          - name: RADAR_NUM_REPLICATION_FACTOR
-            value: "{{ .Values.kafka_num_brokers }}"
           ports:
             - name: http
               containerPort: 9010
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - curl -f localhost:9010/source-types
+            httpGet:
+              path: /source-types
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 60
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - curl -f localhost:9010/source-types
+            httpGet:
+              path: /source-types
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 60
             timeoutSeconds: 5
@@ -122,15 +116,20 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
+              mountPath: /etc/radar-schemas
+            - name: config-schemas
               mountPath: /schema/conf
       volumes:
         - name: config
+          configMap:
+            name: {{ include "catalog-server.fullname" . }}
+        - name: config-schemas
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "catalog-server.fullname" .) }}
         {{- else }}
           emptyDir: {}
-        {{ end }}
+        {{- end }}
         {{- if .Values.cc.enabled }}
         - name: cc-java-config
           configMap:

--- a/charts/catalog-server/values.yaml
+++ b/charts/catalog-server/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 2
 
 image:
-  repository: radarbase/kafka-init
-  tag: 0.5.11-rc0
+  repository: radarbase/radar-schemas-tools
+  tag: 0.7.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -43,7 +43,7 @@ resources:
     memory: 256Mi
 
 persistence:
-  enabled: false
+  enabled: true
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
@@ -56,7 +56,7 @@ persistence:
   ## the existingClaim variable
   # existingClaim: your-claim
   accessMode: ReadWriteOnce
-  size: 1Gi
+  size: 5Mi
 
 nodeSelector: {}
 
@@ -65,8 +65,12 @@ tolerations: []
 affinity: {}
 
 kafka_num_brokers: 3
-zookeeper: cp-zookeeper-headless:2181
+kafka: cp-kafka-headless:9092
 schema_registry: http://cp-schema-registry:8081
+
+specificationsExclude:
+# - active/*
+# - passive/*1.0.0*
 
 cc:
   enabled: false


### PR DESCRIPTION
Exclude specifications with the new `specificationsExclude` property. Default persistent volume to true, to reduce the number of steps to upload new schemas and specifications.