### PR TITLE
Bring kubernetes up to date with radar-helm-charts

### DIFF
--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -56,7 +56,7 @@ releases:
 
   - name: catalog-server
     chart: radar/catalog-server
-    version: 0.2.1
+    version: 0.2.2
     wait: true
     installed: {{ .Values.catalog_server._install }}
     values:

--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-fitbit-connector
     chart: radar/radar-fitbit-connector
-    version: 0.1.1
+    version: 0.1.2
     installed: {{ .Values.radar_fitbit_connector._install }}
     values:
       - {{ .Values.radar_fitbit_connector | toYaml | indent 8 | trim }}
@@ -31,7 +31,7 @@ releases:
 
   - name: radar-rest-sources-authorizer
     chart: radar/radar-rest-sources-authorizer
-    version: 0.2.0
+    version: 0.2.2
     installed: {{ .Values.radar_rest_sources_authorizer._install }}
     values:
       - {{ .Values.radar_rest_sources_authorizer | toYaml | indent 8 | trim }}
@@ -43,7 +43,7 @@ releases:
 
   - name: radar-rest-sources-backend
     chart: radar/radar-rest-sources-backend
-    version: 0.2.0
+    version: 0.2.2
     installed: {{ .Values.radar_rest_sources_backend._install }}
     values:
       - {{ .Values.radar_rest_sources_backend | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-ingestion.yaml
+++ b/helmfile.d/20-ingestion.yaml
@@ -17,7 +17,7 @@ repositories:
 releases:
   - name: radar-gateway
     chart: radar/radar-gateway
-    version: 0.1.4
+    version: 0.1.5
     installed: {{ .Values.radar_gateway._install }}
     values:
       - {{ .Values.radar_gateway | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -60,7 +60,7 @@ releases:
 
   - name: radar-output
     chart: radar/radar-output
-    version: 0.1.1
+    version: 0.1.2
     wait: true
     installed: {{ .Values.radar_output._install }}
     values:


### PR DESCRIPTION
Brings RADAR-Kubernetes up to date with radar-helm-charts, including Log4J fixes.
