### PR TITLE
fix: make fitbit-client-api/secret conditional

### DIFF
--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -22,10 +22,14 @@ releases:
     set:
       - name: kafka_num_brokers
         value: {{ .Values.kafka_num_brokers }}
+      {{- if hasKey .Values "fitbit_api_client" }}
       - name: fitbit_api_client
         value: {{ .Values.fitbit_api_client }}
+      {{- end }}
+      {{- if hasKey .Values "fitbit_api_secret" }}
       - name: fitbit_api_secret
         value: {{ .Values.fitbit_api_secret }}
+      {{- end }}
       - name: oauthClientSecret
         value: {{ if hasKey .Values.management_portal.oauth_clients "radar_fitbit_connector" -}}{{ .Values.management_portal.oauth_clients.radar_fitbit_connector.client_secret }}{{- end }}
 


### PR DESCRIPTION
`helmfile sync --concurrency 1` deployment currently fails setting if they are not defined in helmfile.d/20-fitbit.yaml  `fitbit_api_client` `fitbit_api_secret`. 

**Description of the change**

set the values for `fitbit_api_client` `fitbit_api_secret` conditional on .Values

**Benefits**

helmfile sync works

