### PR TITLE
Chart versions are now configurable via variables

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -6,11 +6,9 @@ postgres_password: password
 
 # --------------------------------------------------------- 00-init.yaml ---------------------------------------------------------
 
-graylog:
-  _install: true
-
 mongodb:
   _install: true
+  _chart_version: 10.11.1
   architecture: replicaset
   auth:
     replicaSetKey: secret
@@ -18,15 +16,23 @@ mongodb:
 
 elasticsearch:
   _install: true
+  _chart_version: 7.12.0
 
-cert_manager:
+graylog:
   _install: true
+  _chart_version: 1.9.2
 
 fluent_bit:
   _install: true
+  _chart_version: 0.15.4
+
+cert_manager:
+  _install: true
+  _chart_version: 0.1.1
 
 kube_prometheus_stack:
   _install: true
+  _chart_version: 0.2.0
   kube-prometheus-stack:
     prometheus:
       prometheusSpec:
@@ -55,6 +61,7 @@ kube_prometheus_stack:
 
 nginx_ingress:
   _install: true
+  _chart_version: 3.25.0
   controller:
     replicaCount: 1
   metrics:
@@ -64,34 +71,11 @@ nginx_ingress:
 
 kafka_manager:
   _install: false
+  _chart_version: 2.1.5
   basicAuth:
     enabled: true
     username: kafkamanager-user
     password: password
-
-velero:
-  _install: false
-  objectStorageBackupReplicaCount: 1
-  local:
-    accessKey: accessKey
-    secretKey: secretKey
-  backup:
-    address: s3.amazon.com  # protocol should not be specified
-    bucket: radar-base-backups
-    accessKey: accessKey
-    secretKey: secretKey
-  velero:
-    configuration:
-      backupStorageLocation:
-        bucket: radar-base-backups
-        config:
-          s3Url: https://s3.amazon.com # protocol should be specified
-    credentials:
-      secretContents:
-        cloud: |
-          [default]
-          aws_access_key_id=accessKey
-          aws_secret_access_key=secretKey
 
 # --------------------------------------------------------- 10-base.yaml ---------------------------------------------------------
 confluent_cloud:
@@ -106,24 +90,31 @@ confluent_cloud:
 
 cp_zookeeper:
   _install: true
+  _chart_version: 0.2.0
   servers: 3
 
 cp_kafka:
   _install: true
+  _chart_version: 0.2.0
   persistence:
     size: 10Gi
 
 cp_schema_registry:
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
 
 catalog_server:
   _install: true
+  _chart_version: 0.3.0
   replicaCount: 1
   schema_registry: http://cp-schema-registry:8081
 
+# --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
+
 postgresql:
   _install: true
+  _chart_version: 9.6.0
   replication:
     enabled: false
   persistence:
@@ -131,6 +122,7 @@ postgresql:
 
 management_portal:
   _install: true
+  _chart_version: 0.2.1
   replicaCount: 1  # should be 1
   postgres:
     host: postgresql
@@ -172,6 +164,7 @@ management_portal:
 
 app_config:
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
   jdbc:
     url: jdbc:postgresql://postgresql:5432/appconfig
@@ -179,9 +172,27 @@ app_config:
 
 app_config_frontend:
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
   authUrl: https://example.com/managementportal/oauth
   authCallbackUrl: https://example.com/appconfig/login
+
+# --------------------------------------------------------- 20-appserver.yaml ---------------------------------------------------------
+
+radar_appserver_postgres_password: password
+
+radar_appserver_postgresql:
+  _install: true
+  _chart_version: 9.6.0
+  persistence:
+    size: 8Gi
+
+radar_appserver:
+  _install: true
+  _chart_version: 0.1.0
+  replicaCount: 1
+  managementportal_resource_name: res_AppServer
+  public_key_endpoints: []
 
 # --------------------------------------------------------- 20-fitbit.yaml ---------------------------------------------------------
 fitbit_api_client: "client"
@@ -189,15 +200,18 @@ fitbit_api_secret: "secret"
 
 radar_fitbit_connector:
   _install: false
+  _chart_version: 0.2.0
   replicaCount: 1
   oauthClientId: radar_fitbit_connector
 
 radar_rest_sources_authorizer:
+  _chart_version: 0.3.0
   _install: false
   replicaCount: 1
 
 radar_rest_sources_backend:
   _install: false
+  _chart_version: 0.3.0
   replicaCount: 1
   postgres:
     host: postgresql
@@ -211,28 +225,63 @@ radar_rest_sources_backend:
     garmin:
       enable: "false"
 
+# --------------------------------------------------------- 20-grafana.yaml ---------------------------------------------------------
+
+timescaledb_db_name: grafana-metrics
+timescaledb_password: password
+timescaledb_username: postgres
+
+grafana_password: password
+grafana_metrics_username: username
+grafana_metrics_password: password
+
+timescaledb:
+  _install: true
+  _chart_version: 9.6.0
+  replicaCount: 1
+  replication:
+    enable: false
+  persistence:
+    size: 8Gi
+
+radar_grafana:
+  _install: true
+  _chart_version: 6.13.0
+  replicaCount: 1
+  env:
+    GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/allprojects/home.json
+
+radar_jdbc_connector:
+  _install: true
+  _chart_version: 0.1.4
+  replicaCount: 1
+
 # --------------------------------------------------------- 20-ingestion.yaml ---------------------------------------------------------
 
 radar_gateway:
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
 
 # --------------------------------------------------------- 20-kafka-analysis.yaml ---------------------------------------------------------
 
 radar_backend_monitor:
   _install: false
+  _chart_version: 0.1.2
   replicaCount: 1
   persistence:
     size: 1Gi
 
 radar_backend_stream:
   _install: false
+  _chart_version: 0.1.2
   replicaCount: 1
 
 # --------------------------------------------------------- 20-redcap.yaml ---------------------------------------------------------
 
 radar_integration:
   _install: false
+  _chart_version: 0.2.0
   replicaCount: 1
   oauth_client_id: radar_redcap_integrator
   projects: []
@@ -245,37 +294,18 @@ radar_integration:
   #    token: xxx
   #    mp_info_project_name: RADAR-BASE
 
-# --------------------------------------------------------- 20-upload.yaml ---------------------------------------------------------
-
-radar_upload_postgres_password: password
-
-radar_upload_postgresql:
-  _install: true
-  persistence:
-    size: 8Gi
-
-radar_upload_connect_backend:
-  _install: true
-  replicaCount: 1
-
-radar_upload_connect_frontend:
-  _install: true
-  replicaCount: 1
-
-radar_upload_source_connector:
-  _install: true
-  replicaCount: 1
-
 # --------------------------------------------------------- 20-s3-connector.yaml ---------------------------------------------------------
 
 redis:
   _install: true
+  _chart_version: 10.6.15
 
 # The access keys and secret keys of the following services should match.
 # If S3 is used as a storage medium instead of minio, then fill in those.
 
 minio:
   _install: true
+  _chart_version: 8.0.10
   replicas: 4
   s3Endpoint: http://minio:9000/
   persistence:
@@ -286,6 +316,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.
   bucketName: radar-intermediate-storage
@@ -296,6 +327,7 @@ radar_s3_connector:
 
 s3_proxy:
   _install: false
+  _chart_version: 0.1.2
   replicaCount: 1
   target:
     provider: azureblob
@@ -305,6 +337,7 @@ s3_proxy:
 
 radar_output:
   _install: true
+  _chart_version: 0.2.0
   replicaCount: 1
   source:
     s3:
@@ -322,61 +355,73 @@ radar_output:
   redis:
     uri: redis://redis-master:6379
 
+# --------------------------------------------------------- 20-upload.yaml ---------------------------------------------------------
+
+radar_upload_postgres_password: password
+
+radar_upload_postgresql:
+  _install: true
+  _chart_version: 9.6.0
+  persistence:
+    size: 8Gi
+
+radar_upload_connect_backend:
+  _install: true
+  _chart_version: 0.2.0
+  replicaCount: 1
+
+radar_upload_connect_frontend:
+  _install: true
+  _chart_version: 0.2.0
+  replicaCount: 1
+
+radar_upload_source_connector:
+  _install: true
+  _chart_version: 0.2.0
+  replicaCount: 1
+
 # --------------------------------------------------------- 30-confluent-cloud.yaml ---------------------------------------------------------
 
 ccSchemaRegistryProxy:
   _install: false
+  _chart_version: 0.2.0
   externalName: schema-registry-domain
-
-# --------------------------------------------------------- 20-grafana.yaml ---------------------------------------------------------
-
-timescaledb_db_name: grafana-metrics
-timescaledb_password: password
-timescaledb_username: postgres
-
-grafana_password: password
-grafana_metrics_username: username
-grafana_metrics_password: password
-
-radar_grafana:
-  _install: true
-  replicaCount: 1
-  env:
-    GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/allprojects/home.json
-
-timescaledb:
-  _install: true
-  replicaCount: 1
-  replication:
-    enable: false
-  persistence:
-    size: 8Gi
-
-radar_jdbc_connector:
-  _install: true
-  replicaCount: 1
 
 # --------------------------------------------------------- 20-push-endpoint.yaml ---------------------------------------------------------
 
 radar_push_endpoint:
   _install: true
+  _chart_version: 0.1.1
   replicaCount: 1
   adminProperties: {}
   garmin:
     enabled: true
     consumerKey: ""
     consumerSecret: ""
-# --------------------------------------------------------- 20-appserver.yaml ---------------------------------------------------------
 
-radar_appserver:
-  _install: true
-  replicaCount: 1
-  managementportal_resource_name: res_AppServer
-  public_key_endpoints: []
-  
-radar_appserver_postgres_password: password
+# --------------------------------------------------------- 99-velero.yaml ---------------------------------------------------------
 
-radar_appserver_postgresql:
-  _install: true
-  persistence:
-    size: 8Gi  
+velero:
+  _install: false
+  _chart_version: 0.1.2
+  objectStorageBackupReplicaCount: 1
+  local:
+    accessKey: accessKey
+    secretKey: secretKey
+  backup:
+    address: s3.amazon.com  # protocol should not be specified
+    bucket: radar-base-backups
+    accessKey: accessKey
+    secretKey: secretKey
+  velero:
+    configuration:
+      backupStorageLocation:
+        bucket: radar-base-backups
+        config:
+          s3Url: https://s3.amazon.com # protocol should be specified
+    credentials:
+      secretContents:
+        cloud: |
+          [default]
+          aws_access_key_id=accessKey
+          aws_secret_access_key=secretKey

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -28,7 +28,7 @@ releases:
   - name: mongodb
     namespace: graylog
     chart: bitnami/mongodb
-    version: 10.11.1
+    version: {{ .Values.mongodb._chart_version }}
     installed: {{ .Values.mongodb._install }}
     values:
       - "../etc/mongodb/values.yaml"
@@ -37,7 +37,7 @@ releases:
   - name: elasticsearch
     namespace: graylog
     chart: elastic/elasticsearch
-    version: 7.12.0
+    version: {{ .Values.elasticsearch._chart_version }}
     installed: {{ .Values.elasticsearch._install }}
     values:
       - "../etc/elasticsearch/values.yaml"
@@ -46,7 +46,7 @@ releases:
   - name: graylog
     namespace: graylog
     chart: kongz/graylog
-    version: 1.9.2
+    version: {{ .Values.graylog._chart_version }}
     installed: {{ .Values.graylog._install }}
     values:
       - "../etc/graylog/values.yaml"
@@ -64,7 +64,7 @@ releases:
   - name: fluent-bit
     namespace: graylog
     chart: fluent/fluent-bit
-    version: 0.15.4
+    version: {{ .Values.fluent_bit._chart_version }}
     installed: {{ .Values.fluent_bit._install }}
     values:
       - "../etc/fluent-bit/values.yaml"
@@ -76,7 +76,7 @@ releases:
     installed: {{ .Values.cert_manager._install }}
     disableValidation: true
     chart: radar/cert-manager
-    version: 0.1.1
+    version: {{ .Values.cert_manager._chart_version }}
     hooks:
       - events: ["presync"]
         showlogs: true
@@ -90,7 +90,7 @@ releases:
 
   - name: kube-prometheus-stack
     chart: radar/kube-prometheus-stack
-    version: 0.2.0
+    version: {{ .Values.kube_prometheus_stack._chart_version }}
     wait: true
     namespace: monitoring
     installed: {{ .Values.kube_prometheus_stack._install }}
@@ -123,7 +123,7 @@ releases:
 
   - name: nginx-ingress
     chart: ingress-nginx/ingress-nginx
-    version: 3.25.0
+    version: {{ .Values.nginx_ingress._chart_version }}
     force: false
     installed: {{ .Values.nginx_ingress._install }}
     disableValidation: true
@@ -133,7 +133,7 @@ releases:
 
   - name: kafka-manager
     chart: radar/kafka-manager
-    version: 2.1.5
+    version: {{ .Values.kafka_manager._chart_version }}
     wait: false
     installed: {{ .Values.kafka_manager._install }}
     values:

--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -17,7 +17,7 @@ repositories:
 releases:
   - name: cp-zookeeper
     chart: cp-radar/cp-zookeeper
-    version: 0.2.0
+    version: {{ .Values.cp_zookeeper._chart_version }}
     wait: true
     installed: {{ .Values.cp_zookeeper._install }}
     values:
@@ -26,7 +26,7 @@ releases:
 
   - name: cp-kafka
     chart: cp-radar/cp-kafka
-    version: 0.2.0
+    version: {{ .Values.cp_kafka._chart_version }}
     wait: true
     installed: {{ .Values.cp_kafka._install }}
     values:
@@ -38,7 +38,7 @@ releases:
 
   - name: cp-schema-registry
     chart: cp-radar/cp-schema-registry
-    version: 0.2.0
+    version: {{ .Values.cp_schema_registry._chart_version }}
     wait: true
     installed: {{ .Values.cp_schema_registry._install }}
     values:
@@ -56,7 +56,7 @@ releases:
 
   - name: catalog-server
     chart: radar/catalog-server
-    version: 0.3.0
+    version: {{ .Values.catalog_server._chart_version }}
     wait: true
     installed: {{ .Values.catalog_server._install }}
     values:

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -16,7 +16,7 @@ helmDefaults:
 releases:
   - name: postgresql
     chart: bitnami/postgresql
-    version: 9.6.0
+    version: {{ .Values.postgresql._chart_version }}
     wait: false
     installed: {{ .Values.postgresql._install }}
     values:
@@ -30,7 +30,7 @@ releases:
 
   - name: management-portal
     chart: radar/management-portal
-    version: 0.2.1
+    version: {{ .Values.management_portal._chart_version }}
     installed: {{ .Values.management_portal._install }}
     values:
       - {{ .Values.management_portal | toYaml | indent 8 | trim }}
@@ -67,7 +67,7 @@ releases:
 
   - name: app-config
     chart: radar/app-config
-    version: 0.2.0
+    version: {{ .Values.app_config._chart_version }}
     installed: {{ .Values.app_config._install }}
     values:
       - {{ .Values.app_config | toYaml | indent 8 | trim }}
@@ -79,7 +79,7 @@ releases:
 
   - name: app-config-frontend
     chart: radar/app-config-frontend
-    version: 0.2.0
+    version: {{ .Values.app_config._chart_version }}
     installed: {{ .Values.app_config_frontend._install }}
     values:
       - {{ .Values.app_config_frontend | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-appserver.yaml
+++ b/helmfile.d/20-appserver.yaml
@@ -1,6 +1,6 @@
 bases:
 - ../environments.yaml
-  
+
 ---
 
 helmDefaults:
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-appserver-postgresql
     chart: bitnami/postgresql
-    version: 9.6.0
+    version: {{ .Values.radar_appserver_postgresql._chart_version }}
     wait: false
     installed: {{ .Values.radar_appserver_postgresql._install }}
     values:
@@ -29,7 +29,7 @@ releases:
 
   - name: radar-appserver
     chart: radar/radar-appserver
-    version: 0.1.0
+    version: {{ .Values.radar_appserver._chart_version }}
     installed: {{ .Values.radar_appserver._install }}
     values:
       - {{ .Values.radar_appserver | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-fitbit-connector
     chart: radar/radar-fitbit-connector
-    version: 0.2.0
+    version: {{ .Values.radar_fitbit_connector._chart_version }}
     installed: {{ .Values.radar_fitbit_connector._install }}
     values:
       - {{ .Values.radar_fitbit_connector | toYaml | indent 8 | trim }}
@@ -35,7 +35,7 @@ releases:
 
   - name: radar-rest-sources-authorizer
     chart: radar/radar-rest-sources-authorizer
-    version: 0.3.0
+    version: {{ .Values.radar_rest_sources_authorizer._chart_version }}
     installed: {{ .Values.radar_rest_sources_authorizer._install }}
     values:
       - {{ .Values.radar_rest_sources_authorizer | toYaml | indent 8 | trim }}
@@ -47,7 +47,7 @@ releases:
 
   - name: radar-rest-sources-backend
     chart: radar/radar-rest-sources-backend
-    version: 0.3.0
+    version: {{ .Values.radar_rest_sources_backend._chart_version }}
     installed: {{ .Values.radar_rest_sources_backend._install }}
     values:
       - {{ .Values.radar_rest_sources_backend | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-grafana.yaml
+++ b/helmfile.d/20-grafana.yaml
@@ -17,7 +17,7 @@ repositories:
 releases:
   - name: timescaledb
     chart: bitnami/postgresql
-    version: 9.6.0
+    version: {{ .Values.timescaledb._chart_version }}
     installed: {{ .Values.timescaledb._install }}
     values:
       - "../etc/timescaledb/values.yaml"
@@ -32,7 +32,7 @@ releases:
 
   - name: radar-grafana
     chart: grafana/grafana
-    version: 6.13.0
+    version: {{ .Values.radar_grafana._chart_version }}
     installed: {{ .Values.radar_grafana._install }}
     values:
       - "../etc/radar-grafana/values.yaml"
@@ -63,7 +63,7 @@ releases:
 
   - name: radar-jdbc-connector
     chart: radar/radar-jdbc-connector
-    version: 0.1.4
+    version: {{ .Values.radar_jdbc_connector._chart_version }}
     installed: {{ .Values.radar_jdbc_connector._install }}
     values:
       - {{ .Values.radar_jdbc_connector | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-ingestion.yaml
+++ b/helmfile.d/20-ingestion.yaml
@@ -17,7 +17,7 @@ repositories:
 releases:
   - name: radar-gateway
     chart: radar/radar-gateway
-    version: 0.2.0
+    version: {{ .Values.radar_gateway._chart_version }}
     installed: {{ .Values.radar_gateway._install }}
     values:
       - {{ .Values.radar_gateway | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-kafka-analysis.yaml
+++ b/helmfile.d/20-kafka-analysis.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-backend-monitor
     chart: radar/radar-backend
-    version: 0.1.2
+    version: {{ .Values.radar_backend_monitor._chart_version }}
     installed: {{ .Values.radar_backend_monitor._install }}
     values:
       - "../etc/radar-backend-monitor/values.yaml"
@@ -26,7 +26,7 @@ releases:
 
   - name: radar-backend-stream
     chart: radar/radar-backend
-    version: 0.1.2
+    version: {{ .Values.radar_backend_monitor._chart_version }}
     installed: {{ .Values.radar_backend_stream._install }}
     values:
       - "../etc/radar-backend-stream/values.yaml"

--- a/helmfile.d/20-redcap.yaml
+++ b/helmfile.d/20-redcap.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-integration
     chart: radar/radar-integration
-    version: 0.2.0
+    version: {{ .Values.radar_integration._chart_version }}
     installed: {{ .Values.radar_integration._install }}
     values:
       - {{ .Values.radar_integration | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -19,7 +19,7 @@ repositories:
 releases:
   - name: redis
     chart: bitnami/redis
-    version: 10.6.15
+    version: {{ .Values.redis._chart_version }}
     installed: {{ .Values.redis._install }}
     values:
       - "../etc/redis/values.yaml"
@@ -27,7 +27,7 @@ releases:
 
   - name: minio
     chart: minio/minio
-    version: 8.0.10
+    version: {{ .Values.minio._chart_version }}
     installed: {{ .Values.minio._install }}
     values:
       - "../etc/minio/values.yaml"
@@ -42,7 +42,7 @@ releases:
 
   - name: radar-s3-connector
     chart: radar/radar-s3-connector
-    version: 0.2.0
+    version: {{ .Values.radar_s3_connector._chart_version }}
     installed: {{ .Values.radar_s3_connector._install }}
     values:
       - {{ .Values.radar_s3_connector | toYaml | indent 8 | trim }}
@@ -53,14 +53,14 @@ releases:
 
   - name: s3-proxy
     chart: radar/s3-proxy
-    version: 0.1.2
+    version: {{ .Values.s3_proxy._chart_version }}
     installed: {{ .Values.s3_proxy._install }}
     values:
       - {{ .Values.s3_proxy | toYaml | indent 8 | trim }}
 
   - name: radar-output
     chart: radar/radar-output
-    version: 0.2.0
+    version: {{ .Values.radar_output._chart_version }}
     wait: true
     installed: {{ .Values.radar_output._install }}
     values:

--- a/helmfile.d/20-upload.yaml
+++ b/helmfile.d/20-upload.yaml
@@ -17,7 +17,7 @@ repositories:
 releases:
   - name: radar-upload-postgresql
     chart: bitnami/postgresql
-    version: 9.6.0
+    version: {{ .Values.radar_upload_postgresql._chart_version }}
     wait: false
     installed: {{ .Values.radar_upload_postgresql._install }}
     values:
@@ -31,7 +31,7 @@ releases:
 
   - name: radar-upload-connect-backend
     chart: radar/radar-upload-connect-backend
-    version: 0.2.0
+    version: {{ .Values.radar_upload_connect_backend._chart_version }}
     installed: {{ .Values.radar_upload_connect_backend._install }}
     values:
       - {{ .Values.radar_upload_connect_backend | toYaml | indent 8 | trim }}
@@ -49,7 +49,7 @@ releases:
 
   - name: radar-upload-connect-frontend
     chart: radar/radar-upload-connect-frontend
-    version: 0.2.0
+    version: {{ .Values.radar_upload_connect_frontend._chart_version }}
     installed: {{ .Values.radar_upload_connect_frontend._install }}
     values:
       - {{ .Values.radar_upload_connect_frontend | toYaml | indent 8 | trim }}
@@ -61,7 +61,7 @@ releases:
 
   - name: radar-upload-source-connector
     chart: radar/radar-upload-source-connector
-    version: 0.2.0
+    version: {{ .Values.radar_upload_source_connector._chart_version }}
     installed: {{ .Values.radar_upload_source_connector._install }}
     values:
       - {{ .Values.radar_upload_source_connector | toYaml | indent 8 | trim }}

--- a/helmfile.d/30-confluent-cloud.yaml
+++ b/helmfile.d/30-confluent-cloud.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: cc-schema-registry-proxy
     chart: radar/cc-schema-registry-proxy
-    version: 0.2.0
+    version: {{ .Values.ccSchemaRegistryProxy._chart_version }}
     installed: {{ .Values.ccSchemaRegistryProxy._install }}
     values:
       - {{ .Values.ccSchemaRegistryProxy | toYaml | indent 8 | trim }}

--- a/helmfile.d/30-push-endpoint.yaml
+++ b/helmfile.d/30-push-endpoint.yaml
@@ -15,7 +15,7 @@ repositories:
 releases:
   - name: radar-push-endpoint
     chart: radar/radar-push-endpoint
-    version: 0.1.1
+    version: {{ .Values.radar_push_endpoint._chart_version }}
     installed: {{ .Values.radar_push_endpoint._install }}
     values:
       - {{ .Values.radar_push_endpoint | toYaml | indent 8 | trim }}

--- a/helmfile.d/99-velero.yaml
+++ b/helmfile.d/99-velero.yaml
@@ -16,7 +16,7 @@ releases:
   - name: velero
     chart: radar/velero
     namespace: velero
-    version: 0.1.2
+    version: {{ .Values.velero._chart_version }}
     installed: {{ .Values.velero._install }}
     values:
       - {{ .Values.velero | toYaml | indent 8 | trim }}


### PR DESCRIPTION
Chart versions now aren't hardcoded in helmfiles and can be changed via variables.
Also shuffled order of charts in `base.yaml` based on their helmfile order.