### PR TITLE
Replace if hasKey chains with dig

### DIFF
--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -91,43 +91,23 @@ releases:
     set:
       - name: ingress.hosts
         values: [ {{ .Values.server_name }} ]
-      {{- if or (not (hasKey .Values.radar_home "s3")) (not (hasKey .Values.radar_home.s3 "enabled")) }}
       - name: s3.enabled
-        value: {{ .Values.minio._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "s3")) (not (hasKey .Values.radar_home.s3 "url")) }}
+        value: {{ dig "s3" "enabled" .Values.minio._install .Values.radar_home }}
       - name: s3.url
-        value: https://s3.{{ .Values.server_name }}/login
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "dashboard")) (not (hasKey .Values.radar_home.dashboard "enabled")) }}
+        value: {{ dig "s3" "url" (printf "https://s3.%s/login" .Values.server_name) .Values.radar_home }}
       - name: dashboard.enabled
-        value: {{ .Values.radar_grafana._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "dashboard")) (not (hasKey .Values.radar_home.dashboard "url")) }}
+        value: {{ dig "dashboard" "enabled" .Values.radar_grafana._install .Values.radar_home }}
       - name: dashboard.url
-        value: https://dashboard.{{ .Values.server_name }}/
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "uploadPortal")) (not (hasKey .Values.radar_home.uploadPortal "enabled")) }}
+        value: {{ dig "dashboard" "url" (printf "https://dashboard.%s/" .Values.server_name) .Values.radar_home }}
       - name: uploadPortal.enabled
-        value: {{ .Values.radar_upload_connect_frontend._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "restAuthorizer")) (not (hasKey .Values.radar_home.restAuthorizer "enabled")) }}
+        value: {{ dig "uploadPortal" "enabled" .Values.radar_upload_connect_frontend._install .Values.radar_home }}
       - name: restAuthorizer.enabled
-        value: {{ .Values.radar_rest_sources_authorizer._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "monitoring")) (not (hasKey .Values.radar_home.monitoring "enabled")) }}
+        value: {{ dig "restAuthorizer" "enabled" .Values.radar_rest_sources_authorizer._install .Values.radar_home }}
       - name: monitoring.enabled
-        value: {{ .Values.kube_prometheus_stack._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "monitoring")) (not (hasKey .Values.radar_home.monitoring "url")) }}
+        value: {{ dig "monitoring" "enabled" .Values.kube_prometheus_stack._install .Values.radar_home }}
       - name: monitoring.url
-        value: https://grafana.{{ .Values.server_name }}/login
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "logging")) (not (hasKey .Values.radar_home.logging "enabled")) }}
+        value: {{ dig "monitoring" "url" (printf "https://grafana.%s/login" .Values.server_name) .Values.radar_home }}
       - name: logging.enabled
-        value: {{ .Values.graylog._install }}
-      {{- end }}
-      {{- if or (not (hasKey .Values.radar_home "logging")) (not (hasKey .Values.radar_home.logging "url")) }}
+        value: {{ dig "logging" "enabled" .Values.graylog._install .Values.radar_home }}
       - name: logging.url
-        value: https://graylog.{{ .Values.server_name }}/
-      {{- end }}
+        value: {{ dig "logging" "url" (printf "https://graylog.%s/" .Values.server_name) .Values.radar_home }}

--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -31,7 +31,7 @@ releases:
         value: {{ .Values.fitbit_api_secret }}
       {{- end }}
       - name: oauthClientSecret
-        value: {{ if hasKey .Values.management_portal.oauth_clients "radar_fitbit_connector" -}}{{ .Values.management_portal.oauth_clients.radar_fitbit_connector.client_secret }}{{- end }}
+        value: {{ dig "radar_fitbit_connector" "client_secret" "" .Values.management_portal.oauth_clients }}
 
   - name: radar-rest-sources-authorizer
     chart: radar/radar-rest-sources-authorizer
@@ -68,15 +68,9 @@ releases:
         value: {{ .Values.radar_fitbit_connector._install }}
       - name: restSourceClients.garmin.enable
         value: {{ and .Values.radar_push_endpoint._install .Values.radar_push_endpoint.garmin.enabled }}
-      {{- if hasKey .Values "radar_push_endpoint.garmin.consumerKey" }}
       - name: restSourceClients.garmin.clientId
-        value: {{ .Values.radar_push_endpoint.garmin.consumerKey }}
-      {{- end }}
-      {{- if hasKey .Values "radar_push_endpoint.garmin.consumerSecret" }}
+        value: {{ dig "restSourceClients" "garmin" "clientId" (dig "garmin" "consumerKey" "" .Values.radar_push_endpoint) .Values.radar_rest_sources_backend }}
       - name: restSourceClients.garmin.clientSecret
-        value: {{ .Values.radar_push_endpoint.garmin.consumerSecret }}
-      {{- end }}
-      {{ if hasKey .Values.management_portal.oauth_clients "radar_rest_sources_auth_backend" }}
+        value: {{ dig "restSourceClients" "garmin" "clientSecret" (dig "garmin" "consumerSecret" "" .Values.radar_push_endpoint) .Values.radar_rest_sources_backend }}
       - name: client_secret
-        value: {{ .Values.management_portal.oauth_clients.radar_rest_sources_auth_backend.client_secret }}
-      {{ end }}
+        value: {{ dig "client_secret" (dig "oauth_clients" "radar_rest_sources_auth_backend" "client_secret" "" .Values.management_portal) .Values.radar_rest_sources_backend }}

--- a/helmfile.d/20-grafana.yaml
+++ b/helmfile.d/20-grafana.yaml
@@ -75,7 +75,5 @@ releases:
         value: {{ .Values.timescaledb_password }}
       - name: jdbc.username
         value: {{ .Values.grafana_metrics_username }}
-      {{- if or (not (hasKey .Values.radar_jdbc_connector "jdbc")) (not (hasKey .Values.radar_jdbc_connector.jdbc "url")) }}
       - name: jdbc.url
-        value: jdbc:postgresql://timescaledb-postgresql-hl:5432/{{ .Values.timescaledb_db_name }}
-      {{- end }}
+        value: {{ dig "jdbc" "url" (printf "jdbc:postgresql://timescaledb-postgresql-hl:5432/%s" .Values.timescaledb_db_name) .Values.radar_jdbc_connector }}

--- a/helmfile.d/20-redcap.yaml
+++ b/helmfile.d/20-redcap.yaml
@@ -22,7 +22,5 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
-      {{ if hasKey .Values.management_portal.oauth_clients "radar_redcap_integrator" }}
       - name: oauth_client_secret
-        value: {{ .Values.management_portal.oauth_clients.radar_redcap_integrator.client_secret }}
-      {{ end }}
+        value: {{ dig "oauth_client_secret" (dig "oauth_clients" "radar_redcap_integrator" "client_secret" "" .Values.management_portal) .Values.radar_integration }}

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -33,20 +33,10 @@ releases:
         value: "s3.{{ .Values.server_name }}"
       - name: apiIngress.hostname
         value: "api.s3.{{ .Values.server_name }}"
-      {{- if hasKey .Values.minio "accessKey" }}
       - name: auth.rootUser
-        value: {{ .Values.minio.accessKey }}
-      {{- else if not (hasKey .Values.minio "auth.rootUser") }}
-      - name: auth.rootUser
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if hasKey .Values.minio "secretKey" }}
+        value: {{ dig "auth" "rootUser" (dig "accessKey" .Values.s3_access_key .Values.minio) .Values.minio }}
       - name: auth.rootPassword
-        value: {{ .Values.minio.secretKey }}
-      {{- else if not (hasKey .Values.minio "auth.rootPassword") }}
-      - name: auth.rootPassword
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
+        value: {{ dig "auth" "rootPassword" (dig "secretKey" .Values.s3_secret_key .Values.minio) .Values.minio }}
 
   - name: radar-s3-connector
     chart: radar/radar-s3-connector
@@ -58,14 +48,10 @@ releases:
     set:
       - name: cc.enabled
         value: {{ .Values.confluent_cloud.enabled }}
-      {{- if not (hasKey .Values.radar_s3_connector "bucketAccessKey") }}
       - name: bucketAccessKey
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.radar_s3_connector "bucketSecretKey") }}
+        value: {{ dig "bucketAccessKey" .Values.s3_access_key .Values.radar_s3_connector }}
       - name: bucketSecretKey
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
+        value: {{ dig "bucketSecretKey" .Values.s3_secret_key .Values.radar_s3_connector }}
 
   - name: s3-proxy
     chart: radar/s3-proxy
@@ -74,14 +60,10 @@ releases:
     values:
       - {{ .Values.s3_proxy | toYaml | indent 8 | trim }}
     set:
-      {{- if not (hasKey .Values.s3_proxy "s3.identity") }}
       - name: s3.identity
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.s3_proxy "s3.credential") }}
+        value: {{ dig "s3" "identity" .Values.s3_access_key .Values.s3_proxy }}
       - name: s3.credential
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
+        value: {{ dig "s3" "credential" .Values.s3_secret_key .Values.s3_proxy }}
 
   - name: radar-output
     chart: radar/radar-output
@@ -91,19 +73,11 @@ releases:
     values:
       - {{ .Values.radar_output | toYaml | indent 8 | trim }}
     set:
-      {{- if not (hasKey .Values.radar_output.source.s3 "accessToken") }}
       - name: source.s3.accessToken
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.radar_output.source.s3 "secretKey") }}
+        value: {{ dig "source" "s3" "accessToken" .Values.s3_access_key .Values.radar_output }}
       - name: source.s3.secretKey
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.radar_output.target.s3 "accessToken") }}
+        value: {{ dig "source" "s3" "secretKey" .Values.s3_secret_key .Values.radar_output }}
       - name: target.s3.accessToken
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.radar_output.target.s3 "secretKey") }}
+        value: {{ dig "target" "s3" "accessToken" .Values.s3_access_key .Values.radar_output }}
       - name: target.s3.secretKey
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
+        value: {{ dig "target" "s3" "secretKey" .Values.s3_secret_key .Values.radar_output }}

--- a/helmfile.d/20-upload.yaml
+++ b/helmfile.d/20-upload.yaml
@@ -40,10 +40,8 @@ releases:
         value: {{ .Values.server_name }}
       - name: postgres.password
         value: {{ .Values.radar_upload_postgres_password }}
-      {{ if hasKey .Values.management_portal.oauth_clients "radar_upload_backend" }}
       - name: client_secret
-        value: {{ .Values.management_portal.oauth_clients.radar_upload_backend.client_secret }}
-      {{ end }}
+        value: {{ dig "client_secret" (dig "oauth_clients" "radar_upload_backend" "client_secret" "" .Values.management_portal) .Values.radar_upload_connect_backend }}
 
   - name: radar-upload-connect-frontend
     chart: radar/radar-upload-connect-frontend
@@ -70,7 +68,5 @@ releases:
         value: {{ .Values.s3_access_key }}
       - name: bucketSecretKey
         value: {{ .Values.s3_secret_key }}
-      {{ if hasKey .Values.management_portal.oauth_clients "radar_upload_connect" }}
       - name: client_secret
-        value: {{ .Values.management_portal.oauth_clients.radar_upload_connect.client_secret }}
-      {{ end }}
+        value: {{ dig "client_secret" (dig "oauth_clients" "radar_upload_connect" "client_secret" "" .Values.management_portal) .Values.radar_upload_source_connector }}

--- a/helmfile.d/30-push-endpoint.yaml
+++ b/helmfile.d/30-push-endpoint.yaml
@@ -37,7 +37,5 @@ releases:
       - name: redis.url
         value: {{ .Values.radar_output.redis.uri }}
       {{ end }}
-      {{ if hasKey .Values.management_portal.oauth_clients "radar_push_endpoint" }}
       - name: garmin.userRepositoryClientSecret
-        value: {{ .Values.management_portal.oauth_clients.radar_push_endpoint.client_secret }}
-      {{ end }}
+        value: {{ dig "garmin" "userRepositoryClientSecret" (dig "oauth_clients" "radar_push_endpoint" "client_secret" "" .Values.management_portal) .Values.radar_push_endpoint }}

--- a/helmfile.d/40-realtime-dashboard.yaml
+++ b/helmfile.d/40-realtime-dashboard.yaml
@@ -28,10 +28,8 @@ releases:
         value: {{ .Values.timescaledb_password }}
       - name: jdbc.username
         value: {{ .Values.grafana_metrics_username }}
-      {{- if or (not (hasKey .Values.radar_jdbc_connector_agg "jdbc")) (not (hasKey .Values.radar_jdbc_connector_agg.jdbc "url")) }}
       - name: jdbc.url
-        value: jdbc:postgresql://timescaledb-postgresql-hl:5432/{{ .Values.timescaledb_db_name }}
-      {{- end }}
+        value: {{ dig "jdbc" "url" (printf "jdbc:postgresql://timescaledb-postgresql-hl:5432/%s" .Values.timescaledb_db_name) .Values.radar_jdbc_connector_agg }}
 
   - name: ksql-server
     chart: cp-radar/cp-ksql-server

--- a/helmfile.d/99-velero.yaml
+++ b/helmfile.d/99-velero.yaml
@@ -21,11 +21,7 @@ releases:
     values:
       - {{ .Values.velero | toYaml | indent 8 | trim }}
     set:
-      {{- if not (hasKey .Values.velero "local.accessKey") }}
       - name: local.accessKey
-        value: {{ .Values.s3_access_key }}
-      {{- end }}
-      {{- if not (hasKey .Values.velero "local.secretKey") }}
+        value: {{ dig "local" "accessKey" .Values.s3_access_key .Values.velero }}
       - name: local.secretKey
-        value: {{ .Values.s3_secret_key }}
-      {{- end }}
+        value: {{ dig "local" "secretKey" .Values.s3_secret_key .Values.velero }}


### PR DESCRIPTION
This removes a lot of `if` /`hasKey` blocks and makes the logic more robust. For example, the `hasKey $dict "key.subkey"` does not work as intended and the `and` function is not short-circuiting so the templates would still throw and exception on a double `if and (hasKey ...) (hasKey ...)` block. Note: dig syntax is

```
dig "key" "subkey" $default $dict
```
The default is only used if the key does not exist, it IS used if it is empty. In some values I've used a nested dig, a first dig to find out if the user set a custom value for the key, and otherwise a dig for an appropriate default value.