### PR TITLE
Parameterise the mongodb connection string for graylog

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -29,6 +29,9 @@ elasticsearch:
 graylog:
   _install: true
   _chart_version: 2.1.2
+  # See https://docs.mongodb.com/manual/reference/connection-string/ for details
+  # E.g, mongodb://graylog:password@mongodb-headless.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0
+  mongodbConnectionString: secret
 
 # Needed for graylog. If graylog is set not to install, this can be disabled as well.
 fluent_bit:

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -39,7 +39,7 @@ releases:
       - {{ .Values.graylog | toYaml | indent 8 | trim }}
     set:
       - name: graylog.mongodb.uri
-        value: mongodb://graylog:{{ index .Values.mongodb.auth.passwords 0 }}@mongodb-headless.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0
+        value: {{ .Values.graylog.mongodbConnectionString }}
       - name: graylog.rootEmail
         value: {{ .Values.maintainer_email }}
       - name: graylog.ingress.hosts


### PR DESCRIPTION
**Description of the change**
Graylog doesn't know whether the underlying MongoDB has auth enabled or not. This PR introduces `mongodbConnectionString` for users to override its MongoDB URI.

**Benefits**
* For backward compatibility, connections to MongoDB deployed to private subnet with auth disabled can continue functioning without the "graylog" user being introduced
* For backward compatibility, Users have the option to alter the hostname, e.g., to mongodb-0.mongodb-headless.graylog.svc.cluster.local
* The `mongodbConnectionString` containing a password can be encrypted as part of production.yaml

**Possible drawbacks**
There is no default valid value for `mongodbConnectionString` in base.yaml.
