### PR TITLE
Support for Kubernetes 1.27

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
   install:
     strategy:
       matrix:
-        KUBECTL_VERSION: ["v1.23.0", "v1.24.0", "v1.25.0", "v1.26.0"]
+        KUBECTL_VERSION: ["v1.23.0", "v1.24.0", "v1.25.0", "v1.26.0", "v1.27.0"]
         include:
           - KUBECTL_VERSION: "v1.23.0"
             K3S_VERSION: "v1.23.17+k3s1"
@@ -24,6 +24,8 @@ jobs:
             K3S_VERSION: "v1.25.8+k3s1"
           - KUBECTL_VERSION: "v1.26.0"
             K3S_VERSION: "v1.26.3+k3s1"
+          - KUBECTL_VERSION: "v1.27.0"
+            K3S_VERSION: "v1.27.1+k3s1"
     runs-on: self-hosted
     steps:
       - name: Cleanup

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ RADAR-Kubernetes is one of the youngest project of RADAR-base and will be the **
 Currently RADAR-Kubernetes is tested and supported on following component versions:
 | Component | Version |
 | ---- | ------- |
-| Kubernetes | v1.23 to v1.26 |
-| K3s | v1.23.17+k3s1 to v1.26.3+k3s1 |
-| Kubectl | v1.23 to v1.26 |
+| Kubernetes | v1.23 to v1.27 |
+| K3s | v1.23.17+k3s1 to v1.27.1+k3s1 |
+| Kubectl | v1.23 to v1.27 |
 | Helm | v3.11.3 |
 | Helm diff | v3.6.0 |
 | Helmfile | v0.152.0 |


### PR DESCRIPTION
This version released last month and by the looks of it we don't need to change anything for compatibility. 
https://kubernetes.io/blog/2023/04/11/kubernetes-v1-27-release/

They added a few interesting features that we can implement in the helm charts later.