### PR TITLE
Updated Minio version

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -356,7 +356,7 @@ minio:
   _chart_version: 11.9.1
   _extra_timeout: 210
   image:
-    tag: 2022.10.15-debian-11-r0
+    tag: 2023-debian-11
   persistence:
     size: 20Gi
   metrics:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -353,10 +353,8 @@ redis:
 
 minio:
   _install: true
-  _chart_version: 11.9.1
+  _chart_version: 12.6.9
   _extra_timeout: 210
-  image:
-    tag: 2023-debian-11
   persistence:
     size: 20Gi
   metrics:


### PR DESCRIPTION
Fixes the CVE-2023-28432 critical vulnerability on Minio
https://cve.report/CVE-2023-28432