### PR TITLE
Use helmfile dependency management

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -81,7 +81,7 @@ jobs:
           echo "kubeconfig: $KUBECONFIG"
           kubectl get pods --all-namespaces
 
-          helmfile sync --concurrency 1
+          helmfile sync
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Manually triggered tmate session
@@ -102,6 +102,19 @@ jobs:
         run: |
           kubectl get pods --all-namespaces
 
+      - name: Prepare the logs for upload
+        if: always()
+        run: |
+          sudo chmod -R 777 /var/log/pods
+          
+      - name: Upload logs as artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: kubenretes-logs-${{ matrix.K3S_VERSION }}
+          path: /var/log/pods
+          if-no-files-found: ignore
+          
   check-gitignore:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -83,6 +83,11 @@ jobs:
 
           helmfile sync
 
+      - name: Report cluster state
+        if: always()
+        run: |
+          kubectl get pods --all-namespaces
+
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Manually triggered tmate session
         uses: mxschmitt/action-tmate@v3
@@ -109,19 +114,16 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Report cluster state
-        if: always()
-        run: |
-          kubectl get pods --all-namespaces
-
+      # Takes very long to upload artifcats for some reason
+      # https://github.com/RADAR-base/RADAR-Kubernetes/actions/runs/5642728153/job/15283146473
       - name: Prepare the logs for upload
-        if: always()
+        if: ${{ failure() }}
         run: |
           sudo chmod -R 777 /var/log/pods
 
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
-        if: always()
+        if: ${{ failure() }}
         with:
           name: kubenretes-logs-${{ matrix.K3S_VERSION }}
           path: /var/log/pods

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -90,6 +90,18 @@ jobs:
         with:
           limit-access-to-actor: true
 
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: ci-notifications
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: 'The job has failed, go to https://github.com/RADAR-base/RADAR-Kubernetes/actions and use SSH for more information'
+          SLACK_TITLE: Post Title
+          SLACK_USERNAME: rtCamp
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
       - name: Setup tmate session if jobs have failed
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
@@ -106,7 +118,7 @@ jobs:
         if: always()
         run: |
           sudo chmod -R 777 /var/log/pods
-          
+
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v3
         if: always()

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Once all configuration files are ready, the RADAR-Kubernetes can be deployed on 
 #### Install RADAR-Kubernetes on your cluster.
 
 ```shell
-helmfile sync --concurrency 1
+helmfile sync
 ```
 
 The `helmfile sync` will synchronize all the Kubernetes resources defined in the helmfiles with your Kubernetes cluster. Having `--concurrency 1` will make sure components are installed in required order. Depending on your cluster specification, this may take around 30 minutes when installed for the first time.
@@ -402,6 +402,7 @@ In `production.yaml` rename sections:
 | radar_jdbc_connector_agg | radar_jdbc_connector_realtime_dashboard |
 
 ### Upgrade to RADAR-Kubernetes version 1.1.x
+
 Before running the upgrade make sure to copy `environments.yaml.tmpl` to `environments.yaml` and if you've previously changed `environments.yaml` apply the changes again. This is necessary due to addition of `helmDefaults` and `repositories` configurations to this file.
 
 ### Upgrade to RADAR-Kubernetes version 1.0.0

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -47,9 +47,6 @@ cert_manager:
     podSecurityPolicy:
       enabled: false
       useAppArmor: false
-  prometheus:
-    servicemonitor:
-      enabled: true
 
 # Should be installed at least once to get the necessary resource definitions.
 # If disabled, you can still install those definitions with the command:
@@ -96,8 +93,6 @@ nginx_ingress:
     # Prometheus metrics exporter
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
 
 # Kafka manager is outdated but can still be used. Otherwise, use Kafka command-line tools.
 kafka_manager:
@@ -436,11 +431,6 @@ minio:
   _extra_timeout: 210
   persistence:
     size: 20Gi
-  metrics:
-    serviceMonitor:
-      enabled: true
-    prometheusRule:
-      enabled: true
   provisioning:
     ## @param provisioning.users MinIO&reg; users provisioning. Can be used in addition to provisioning.usersExistingSecrets.
     ## https://docs.min.io/docs/minio-admin-complete-guide.html#user

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -34,7 +34,7 @@ releases:
     version: {{ .Values.graylog._chart_version }}
     installed: {{ .Values.graylog._install }}
     timeout: {{ add .Values.base_timeout .Values.graylog._extra_timeout }}
-    needs:
+    needs: # TODO: Fix the map so it wouldn't break if monogo and elastic both won't be installed
       {{ if .Values.mongodb._install }}- graylog/mongodb{{ end }}
       {{ if .Values.elasticsearch._install }}- graylog/elasticsearch{{ end }}    
     <<: *logFailedRelease
@@ -131,7 +131,7 @@ releases:
     set:
       - name: controller.metrics.serviceMonitor.enabled
         value: {{ .Values.kube_prometheus_stack._install }}
-        
+
   - name: kafka-manager
     chart: radar/kafka-manager
     version: {{ .Values.kafka_manager._chart_version }}

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -34,6 +34,9 @@ releases:
     version: {{ .Values.graylog._chart_version }}
     installed: {{ .Values.graylog._install }}
     timeout: {{ add .Values.base_timeout .Values.graylog._extra_timeout }}
+    needs:
+      {{ if .Values.mongodb._install }}- graylog/mongodb{{ end }}
+      {{ if .Values.elasticsearch._install }}- graylog/elasticsearch{{ end }}    
     <<: *logFailedRelease
     values:
       - "../etc/graylog/values.yaml"
@@ -56,6 +59,7 @@ releases:
     version: {{ .Values.fluent_bit._chart_version }}
     installed: {{ .Values.fluent_bit._install }}
     timeout: {{ add .Values.base_timeout .Values.fluent_bit._extra_timeout }}
+    {{ if .Values.graylog._install }}needs: [graylog/graylog]{{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/fluent-bit/values.yaml"
@@ -105,21 +109,29 @@ releases:
     installed: {{ .Values.cert_manager._install }}
     timeout: {{ add .Values.base_timeout .Values.cert_manager._extra_timeout }}
     disableValidation: true
+    {{ if .Values.kube_prometheus_stack._install }}needs: [monitoring/kube-prometheus-stack]{{ end }}
     <<: *logFailedReleaseCertManager
     values:
       - {{ .Values.cert_manager | toYaml | indent 8 | trim }}
+    set:
+      - name: global.prometheus.servicemonitor.enabled
+        value: {{ .Values.kube_prometheus_stack._install }}      
 
   - name: nginx-ingress
     chart: radar/ingress-nginx
     version: {{ .Values.nginx_ingress._chart_version }}
     installed: {{ .Values.nginx_ingress._install }}
     timeout: {{ add .Values.base_timeout .Values.nginx_ingress._extra_timeout }}
+    {{ if .Values.kube_prometheus_stack._install }}needs: [monitoring/kube-prometheus-stack]{{ end }}
     disableValidation: true
     <<: *logFailedRelease
     values:
       - "../etc/nginx-ingress/values.yaml"
       - {{ .Values.nginx_ingress | toYaml | indent 8 | trim }}
-
+    set:
+      - name: controller.metrics.serviceMonitor.enabled
+        value: {{ .Values.kube_prometheus_stack._install }}
+        
   - name: kafka-manager
     chart: radar/kafka-manager
     version: {{ .Values.kafka_manager._chart_version }}

--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -34,6 +34,7 @@ releases:
     installed: {{ .Values.cp_kafka._install }}
     timeout: {{ add .Values.base_timeout .Values.cp_kafka._extra_timeout }}
     wait: true
+    {{ if .Values.cp_zookeeper._install }}needs: [cp-zookeeper]{{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/cp-kafka/values.yaml"
@@ -48,6 +49,7 @@ releases:
     installed: {{ .Values.cp_schema_registry._install }}
     timeout: {{ add .Values.base_timeout .Values.cp_schema_registry._extra_timeout }}
     wait: true
+    {{ if .Values.cp_kafka._install }}needs: [cp-kafka]{{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/cp-schema-registry/values.yaml"
@@ -68,6 +70,7 @@ releases:
     installed: {{ .Values.catalog_server._install }}
     timeout: {{ add .Values.base_timeout .Values.catalog_server._extra_timeout }}
     wait: true
+    {{ if .Values.cp_schema_registry._install }}needs: [cp-schema-registry]{{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.catalog_server | toYaml | indent 8 | trim }}

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -21,6 +21,7 @@ releases:
     version: {{ .Values.management_portal._chart_version }}
     installed: {{ .Values.management_portal._install }}
     timeout: {{ add .Values.base_timeout .Values.management_portal._extra_timeout }}
+    {{ if .Values.postgresql._install }}needs: [postgresql]{{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.management_portal | toYaml | indent 8 | trim }}
@@ -62,6 +63,7 @@ releases:
     version: {{ .Values.app_config._chart_version }}
     installed: {{ .Values.app_config._install }}
     timeout: {{ add .Values.base_timeout .Values.app_config._extra_timeout }}
+    {{ if .Values.postgresql._install }}needs: [postgresql]{{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.app_config | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-appserver.yaml
+++ b/helmfile.d/20-appserver.yaml
@@ -21,6 +21,7 @@ releases:
     version: {{ .Values.radar_appserver._chart_version }}
     installed: {{ .Values.radar_appserver._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_appserver._extra_timeout }}
+    {{ if .Values.radar_appserver_postgresql._install }}needs: [radar-appserver-postgresql]{{ end }}
     <<: *logFailedRelease    
     needs:
     - radar-appserver-postgresql

--- a/helmfile.d/20-appserver.yaml
+++ b/helmfile.d/20-appserver.yaml
@@ -23,8 +23,6 @@ releases:
     timeout: {{ add .Values.base_timeout .Values.radar_appserver._extra_timeout }}
     {{ if .Values.radar_appserver_postgresql._install }}needs: [radar-appserver-postgresql]{{ end }}
     <<: *logFailedRelease    
-    needs:
-    - radar-appserver-postgresql
     values:
       - {{ .Values.radar_appserver | toYaml | indent 8 | trim }}
     set:

--- a/helmfile.d/20-dashboard.yaml
+++ b/helmfile.d/20-dashboard.yaml
@@ -33,6 +33,10 @@ releases:
     version: {{ .Values.radar_grafana._chart_version }}
     installed: {{ .Values.radar_grafana._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_grafana._extra_timeout }}
+    {{ if .Values.timescaledb._install }}
+    needs:
+      - timescaledb
+    {{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/radar-grafana/values.yaml"
@@ -66,6 +70,8 @@ releases:
     version: {{ .Values.data_dashboard_backend._chart_version }}
     installed: {{ .Values.data_dashboard_backend._install }}
     timeout: {{ add .Values.base_timeout .Values.data_dashboard_backend._extra_timeout }}
+    needs:
+      - timescaledb
     <<: *logFailedRelease
     values:
       - {{ .Values.data_dashboard_backend | toYaml | indent 8 | trim }}
@@ -89,6 +95,11 @@ releases:
     installed: {{ .Values.ksql_server._install }}
     version: {{ .Values.ksql_server._chart_version }}
     timeout: {{ add .Values.base_timeout .Values.ksql_server._extra_timeout }}
+    {{ if .Values.cp_kafka._install }}
+    needs:
+      - cp-kafka
+      - cp-schema-registry
+    {{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/cp-ksql-server/values.yaml"
@@ -99,6 +110,14 @@ releases:
     version: {{ .Values.radar_jdbc_connector_grafana._chart_version }}
     installed: {{ .Values.radar_jdbc_connector_grafana._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_jdbc_connector_grafana._extra_timeout }}
+    {{ if or .Values.timescaledb._install .Values.cp_kafka._install }}
+    needs:
+      {{ if .Values.timescaledb._install }}- timescaledb{{ end }}
+      {{ if .Values.cp_kafka._install }}
+      - cp-kafka
+      - cp-schema-registry
+      {{ end }}
+    {{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.radar_jdbc_connector_grafana | toYaml | indent 8 | trim }}
@@ -117,6 +136,14 @@ releases:
     version: {{ .Values.radar_jdbc_connector_data_dashboard_backend._chart_version }}
     installed: {{ .Values.radar_jdbc_connector_data_dashboard_backend._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_jdbc_connector_data_dashboard_backend._extra_timeout }}
+    {{ if or .Values.timescaledb._install .Values.cp_kafka._install }}
+    needs:
+      {{ if .Values.timescaledb._install }}- timescaledb{{ end }}
+      {{ if .Values.cp_kafka._install }}
+      - cp-kafka
+      - cp-schema-registry
+      {{ end }}
+    {{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/radar-jdbc-connector-data-dashboard-backend/values.yaml"
@@ -136,6 +163,14 @@ releases:
     version: {{ .Values.radar_jdbc_connector_realtime_dashboard._chart_version }}
     installed: {{ .Values.radar_jdbc_connector_realtime_dashboard._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_jdbc_connector_realtime_dashboard._extra_timeout }}
+    {{ if or .Values.timescaledb._install .Values.cp_kafka._install }}
+    needs:
+      {{ if .Values.timescaledb._install }}- timescaledb{{ end }}
+      {{ if .Values.cp_kafka._install }}
+      - cp-kafka
+      - cp-schema-registry
+      {{ end }}
+    {{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/radar-jdbc-connector-realtime-dashboard/values.yaml"

--- a/helmfile.d/20-kafka-analysis.yaml
+++ b/helmfile.d/20-kafka-analysis.yaml
@@ -11,6 +11,14 @@ releases:
     version: {{ .Values.radar_backend_monitor._chart_version }}
     installed: {{ .Values.radar_backend_monitor._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_backend_monitor._extra_timeout }}
+    {{ if .Values.cp_kafka._install }}
+    needs:
+      - cp-zookeeper
+      - cp-kafka
+      - cp-schema-registry
+      # Does this still exist?
+      # - cp-kafka-rest
+    {{ end }}
     <<: *logFailedRelease
     values:
       - "../etc/radar-backend-monitor/values.yaml"
@@ -24,6 +32,14 @@ releases:
     version: {{ .Values.radar_backend_monitor._chart_version }}
     installed: {{ .Values.radar_backend_stream._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_backend_stream._extra_timeout }}
+    {{ if .Values.cp_kafka._install }}
+    needs:
+      - cp-zookeeper
+      - cp-kafka
+      - cp-schema-registry
+      # Does this still exist?
+      # - cp-kafka-rest
+    {{ end }}
     <<: *logFailedRelease    
     values:
       - "../etc/radar-backend-stream/values.yaml"

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -80,6 +80,7 @@ releases:
     timeout: {{ add .Values.base_timeout .Values.radar_output._extra_timeout }}
     <<: *logFailedRelease
     needs:
+      - radar-s3-connector
       {{ if .Values.redis._install }}- redis{{ end }}
       {{ if .Values.minio._install }}- minio{{ end }}
     values:

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -44,7 +44,14 @@ releases:
     version: {{ .Values.radar_s3_connector._chart_version }}
     installed: {{ .Values.radar_s3_connector._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_s3_connector._extra_timeout }}
-    {{ if .Values.minio._install }}needs: [minio]{{ end }}
+    {{ if or .Values.minio._install .Values.cp_kafka._install }}
+    needs:
+      {{ if .Values.minio._install }}- minio{{ end }}
+      {{ if .Values.cp_kafka._install }}
+      - cp-kafka
+      - cp-schema-registry
+      {{ end }}
+    {{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.radar_s3_connector | toYaml | indent 8 | trim }}

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -34,12 +34,17 @@ releases:
         value: {{ dig "auth" "rootUser" (dig "accessKey" .Values.s3_access_key .Values.minio) .Values.minio }}
       - name: auth.rootPassword
         value: {{ dig "auth" "rootPassword" (dig "secretKey" .Values.s3_secret_key .Values.minio) .Values.minio }}
+      - name: metrics.serviceMonitor.enabled
+        value: {{ .Values.kube_prometheus_stack._install }}
+      - name: metrics.prometheusRule.enabled
+        value: {{ .Values.kube_prometheus_stack._install }}
 
   - name: radar-s3-connector
     chart: radar/radar-s3-connector
     version: {{ .Values.radar_s3_connector._chart_version }}
     installed: {{ .Values.radar_s3_connector._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_s3_connector._extra_timeout }}
+    {{ if .Values.minio._install }}needs: [minio]{{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.radar_s3_connector | toYaml | indent 8 | trim }}
@@ -74,6 +79,9 @@ releases:
     installed: {{ .Values.radar_output._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_output._extra_timeout }}
     <<: *logFailedRelease
+    needs:
+      {{ if .Values.redis._install }}- redis{{ end }}
+      {{ if .Values.minio._install }}- minio{{ end }}
     values:
       - {{ .Values.radar_output | toYaml | indent 8 | trim }}
     set:

--- a/helmfile.d/20-upload.yaml
+++ b/helmfile.d/20-upload.yaml
@@ -59,7 +59,9 @@ releases:
     version: {{ .Values.radar_upload_source_connector._chart_version }}
     installed: {{ .Values.radar_upload_source_connector._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_upload_source_connector._extra_timeout }}
-    <<: *logFailedRelease    
+    <<: *logFailedRelease
+    needs:
+    - radar-upload-connect-backend
     values:
       - {{ .Values.radar_upload_source_connector | toYaml | indent 8 | trim }}
     set:

--- a/helmfile.d/20-upload.yaml
+++ b/helmfile.d/20-upload.yaml
@@ -26,6 +26,7 @@ releases:
     version: {{ .Values.radar_upload_connect_backend._chart_version }}
     installed: {{ .Values.radar_upload_connect_backend._install }}
     timeout: {{ add .Values.base_timeout .Values.radar_upload_connect_backend._extra_timeout }}
+    {{ if .Values.radar_upload_postgresql._install }}needs: [radar-upload-postgresql]{{ end }}
     <<: *logFailedRelease
     values:
       - {{ .Values.radar_upload_connect_backend | toYaml | indent 8 | trim }}


### PR DESCRIPTION
Apparently you can use helmfile to manage dependencies so we don't have to use --concurrency 1 flag anymore. However right now this assumes that all dependencies like Kafka, S3 and Postgresql are all installed on the cluster, this needs to be fixed before the PR is ready. However it's still possible to ignore dependency management system with --skip-needs flag.

Continued from #221 