### PR TITLE
Fix path to appserver postgress password

### DIFF
--- a/helmfile.d/20-appserver.yaml
+++ b/helmfile.d/20-appserver.yaml
@@ -31,3 +31,5 @@ releases:
         values: [{{ .Values.server_name }}]
       - name: serverName
         value: {{ .Values.server_name }}
+      - name: postgres.password
+        value: {{ .Values.radar_appserver.postgres.password }}


### PR DESCRIPTION
# Background
According to a commit by Joris in another branch, the database password is not correctly passed to the appserver application. I a recent change to the base-secrets.yaml file, Keyvan changed the path to the appserver database password secret.

# Change
This PR will add the password at the correct path to 20-appserver.yaml helmfile.

# Checklist
?
