### PR TITLE
[radar-gateway] Configure radar-gataway to mitigate XSS attack vector

### DIFF
--- a/etc/radar-gateway/values.yaml
+++ b/etc/radar-gateway/values.yaml
@@ -1,0 +1,8 @@
+ingress:
+  annotations:
+    # Nginx decodes the uri before passing it to the backend server. This is dangerous because it can allow for XSS
+    # attacks. Grizzly servers have a bug where they send the decoded uri as part of error messages (see
+    # https://github.com/Graylog2/graylog2-server/issues/3171). To prevent this, we need to re-encode the uri
+    # ($request_uri is the original encoded request) before passing it to the Grizzly server.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^ $request_uri;

--- a/helmfile.d/20-ingestion.yaml
+++ b/helmfile.d/20-ingestion.yaml
@@ -13,6 +13,7 @@ releases:
     timeout: {{ add .Values.base_timeout .Values.radar_gateway._extra_timeout }}
     <<: *logFailedRelease    
     values:
+      - "../etc/radar-gateway/values.yaml"
       - {{ .Values.radar_gateway | toYaml | indent 8 | trim }}
       - {{ .Values.confluent_cloud | toYaml | indent 8 | trim }}
     set:


### PR DESCRIPTION
# Background
Nginx decodes the uri before passing it to the backend server. This is dangerous because it can allow for XSS attacks. Grizzly servers have a bug where they send the decoded uri as part of error messages (see https://github.com/Graylog2/graylog2-server/issues/3171). 

# Change 
To prevent XSS attacks, we need to re-encode the uri ($request_uri is the original encoded request) before passing it to the Grizzly server.