### PR TITLE
Reuse TLS secrets between services with the same hostname

### DIFF
--- a/etc/kratos/values.yaml
+++ b/etc/kratos/values.yaml
@@ -1,0 +1,11 @@
+ingress:
+  admin:
+    tls:
+      - secretName: radar-base-tls
+        hosts:
+          - localhost
+  public:
+    tls:
+      - secretName: radar-base-tls
+        hosts:
+          - localhost

--- a/etc/kratos_ui/values.yaml
+++ b/etc/kratos_ui/values.yaml
@@ -1,0 +1,5 @@
+ingress:
+  tls:
+    - secretName: radar-base-tls
+      hosts:
+        - localhost

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -45,10 +45,12 @@ releases:
         value: {{ .Values.maintainer_email }}
       - name: graylog.ingress.hosts
         values: [graylog.{{ .Values.server_name }}]
-      - name: graylog.ingress.tls[0].secretName
-        value: radar-base-tls
       - name: graylog.ingress.tls[0].hosts
         values: ["graylog.{{ .Values.server_name }}"]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: graylog.ingress.tls[0].secretName
+        value: radar-base-tls-graylog
+      # ---
 
   - name: fluent-bit
     namespace: graylog
@@ -79,24 +81,30 @@ releases:
         value: {{ .Values.server_name }}
       - name: kube-prometheus-stack.prometheus.ingress.hosts
         values: ["prometheus.{{ .Values.server_name }}"]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].secretName
         value: radar-base-tls-prometheus
+      # ---
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].hosts
         values: ["prometheus.{{ .Values.server_name }}"]
 
       - name: kube-prometheus-stack.alertmanager.ingress.hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].secretName
         value: radar-base-tls-alertmanager
+      # ---
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
 
       - name: kube-prometheus-stack.grafana.ingress.hosts
         values: ["grafana.{{ .Values.server_name }}"]
-      - name: kube-prometheus-stack.grafana.ingress.tls[0].secretName
-        value: radar-base-tls-grafana
       - name: kube-prometheus-stack.grafana.ingress.tls[0].hosts
         values: ["grafana.{{ .Values.server_name }}"]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: kube-prometheus-stack.grafana.ingress.tls[0].secretName
+        value: radar-base-tls-grafana
+      # ---
 
   - name: cert-manager
     namespace: cert-manager
@@ -132,8 +140,10 @@ releases:
       - name: ingress.hosts
         values:
           - {{ .Values.server_name }}
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
       - name: ingress.tls.secretName
         value: radar-base-tls
+      # ---
       - name: ingress.tls.hosts
         values:
           - {{ .Values.server_name }}

--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -57,8 +57,10 @@ releases:
         value: "{{ .Values.server_name }}"
       - name: ingress.hosts[0].paths
         values: ["/schema/?(.*)"]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
       - name: ingress.tls[0].secretName
         value: radar-base-tls
+      # ---
       - name: ingress.tls[0].hosts
         values: ["{{ .Values.server_name }}"]
 
@@ -93,6 +95,10 @@ releases:
     set:
       - name: ingress.hosts
         values: [ {{ .Values.server_name }} ]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: s3.enabled
         value: {{ dig "s3" "enabled" .Values.minio._install .Values.radar_home }}
       - name: s3.url

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -29,6 +29,12 @@ releases:
         values: [{{ .Values.server_name }}]
       - name: ingress_rate_limited.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secrets in sync with hostnames (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      - name: ingress_rate_limited.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: server_name
         value: {{ .Values.server_name }}
       - name: oauth_clients.radar_redcap_integrator.enable
@@ -68,6 +74,10 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: clientSecret
         value: {{ .Values.management_portal.oauth_clients.radar_appconfig.client_secret }}
 
@@ -82,6 +92,10 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: authUrl
         value: https://{{ .Values.server_name }}/managementportal/oauth
       - name: authCallbackUrl

--- a/helmfile.d/20-appserver.yaml
+++ b/helmfile.d/20-appserver.yaml
@@ -29,5 +29,9 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: serverName
         value: {{ .Values.server_name }}

--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -35,10 +35,15 @@ releases:
     timeout: {{ add .Values.base_timeout .Values.radar_rest_sources_authorizer._extra_timeout }}
     <<: *logFailedRelease
     values:
+      - "../etc/radar-rest-sources-authorizer/values.yaml"
       - {{ .Values.radar_rest_sources_authorizer | toYaml | indent 8 | trim }}
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: serverName
         value: {{ .Values.server_name }}
 
@@ -53,6 +58,10 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: serverName
         value: {{ .Values.server_name }}
       {{- if hasKey .Values "fitbit_api_client" }}

--- a/helmfile.d/20-grafana.yaml
+++ b/helmfile.d/20-grafana.yaml
@@ -48,8 +48,10 @@ releases:
         values: ["dashboard.{{ .Values.server_name }}"]
       - name: "grafana\\.ini.server.root_url"
         value: "https://dashboard.{{ .Values.server_name }}/"
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
       - name: ingress.tls[0].secretName
         value: radar-base-tls-dashboard
+      # ---
       - name: ingress.tls[0].hosts
         values: ["dashboard.{{ .Values.server_name }}"]
       - name: "grafana\\.ini.metrics.basic_auth_username"

--- a/helmfile.d/20-ingestion.yaml
+++ b/helmfile.d/20-ingestion.yaml
@@ -18,6 +18,10 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      # --- Keep in secret in sync with hostname (main and subdomains have dedicated secrets)
+      - name: ingress.tls.secretName
+        value: radar-base-tls
+      # ---
       - name: cc.enabled
         value: {{ .Values.confluent_cloud.enabled }}
       - name: serviceMonitor.enabled


### PR DESCRIPTION
# Problem
Services with the same hostname are coupled with different TLS certificate secrets. This will trigger cert-manager to file different requests to LetsEncrypt for the same domain. This will needlessly exhaust the request limit and has caused problems with failing requests upon repeated reinstalls.

# Solution
This PR will improve the situation by sharing TLS secrets between services with the same hostname.

# Notes
- Exhaustion of certificate requests can be prevented by using the staging ACME of LetsEncrypt. I have not been able to use the staging environment in a preliminary attempt.
- I have added the Ory Kratos secrets as a reminder for this new service in the future,
- I think that the graylog service was not using the correct secret name. Or is this secret name reuse ok because graylog uses a different namespace?