### PR TITLE
Fix nesting 00 init

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
   install:
     strategy:
       matrix:
-        KUBECTL_VERSION: ["v1.23.0", "v1.24.0", "v1.25.0", "v1.26.0"]
+        KUBECTL_VERSION: ["v1.23.0", "v1.24.0", "v1.25.0", "v1.26.0", "v1.27.0"]
         include:
           - KUBECTL_VERSION: "v1.23.0"
             K3S_VERSION: "v1.23.17+k3s1"
@@ -24,6 +24,8 @@ jobs:
             K3S_VERSION: "v1.25.8+k3s1"
           - KUBECTL_VERSION: "v1.26.0"
             K3S_VERSION: "v1.26.3+k3s1"
+          - KUBECTL_VERSION: "v1.27.0"
+            K3S_VERSION: "v1.27.1+k3s1"
     runs-on: self-hosted
     steps:
       - name: Cleanup

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ RADAR-Kubernetes is one of the youngest project of RADAR-base and will be the **
 Currently RADAR-Kubernetes is tested and supported on following component versions:
 | Component | Version |
 | ---- | ------- |
-| Kubernetes | v1.23 to v1.26 |
-| K3s | v1.23.17+k3s1 to v1.26.3+k3s1 |
-| Kubectl | v1.23 to v1.26 |
+| Kubernetes | v1.23 to v1.27 |
+| K3s | v1.23.17+k3s1 to v1.27.1+k3s1 |
+| Kubectl | v1.23 to v1.27 |
 | Helm | v3.11.3 |
 | Helm diff | v3.6.0 |
 | Helmfile | v0.152.0 |

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -56,7 +56,7 @@ cert_manager:
 # kubectl --context <my-context> apply --force-conflicts --server-side -f etc/kube-prometheus-stack/files/crds.yaml
 kube_prometheus_stack:
   _install: true
-  _chart_version: 0.4.0
+  _chart_version: 0.4.1
   _extra_timeout: 0
   kube-prometheus-stack:
     prometheus:
@@ -109,7 +109,7 @@ kafka_manager:
 # Use letsencrypt to retrieve SSL certificates.
 cert_manager_letsencrypt:
   _install: true
-  _chart_version: 0.1.0
+  _chart_version: 0.1.1
   _extra_timeout: 0
 
 # Use confluent cloud instead of a local Kafka cluster.
@@ -148,14 +148,14 @@ cp_schema_registry:
 
 catalog_server:
   _install: true
-  _chart_version: 0.4.3
+  _chart_version: 0.4.6
   _extra_timeout: 90
   replicaCount: 1
   schema_registry: http://cp-schema-registry:8081
 
 radar_home:
   _install: true
-  _chart_version: 0.1.1
+  _chart_version: 0.1.3
   _extra_timeout: 0
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
@@ -163,7 +163,7 @@ radar_home:
 # This Postgresql is used for Management Portal and App config, postgres password should be same in them
 postgresql:
   _install: true
-  _chart_version: 11.1.24
+  _chart_version: 12.1.9
   _extra_timeout: 0
   # Check https://hub.docker.com/r/bitnami/postgresql/tags
   # On first install, choose the latest major version. This cannot be modified afterwards
@@ -179,7 +179,7 @@ postgresql:
 
 management_portal:
   _install: true
-  _chart_version: 0.2.5
+  _chart_version: 1.0.0
   _extra_timeout: 210
   replicaCount: 1  # should be 1
   postgres:
@@ -196,7 +196,7 @@ management_portal:
 
 app_config:
   _install: true
-  _chart_version: 0.2.4
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
   jdbc:
@@ -204,7 +204,7 @@ app_config:
 
 app_config_frontend:
   _install: true
-  _chart_version: 0.2.3
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -212,7 +212,7 @@ app_config_frontend:
 # The charts in 20-appserver.yaml only need to be installed if you have a custom aRMT app.
 radar_appserver_postgresql:
   _install: false
-  _chart_version: 11.1.24
+  _chart_version: 12.1.9
   _extra_timeout: 0
   # Check https://hub.docker.com/r/bitnami/postgresql/tags
   # On first install, choose the latest major version. This cannot be modified afterwards
@@ -226,7 +226,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.1.4
+  _chart_version: 0.1.6
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer
@@ -236,20 +236,20 @@ radar_appserver:
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit or Garmin API integration.
 radar_fitbit_connector:
   _install: false
-  _chart_version: 0.2.1
+  _chart_version: 0.2.3
   _extra_timeout: 0
   replicaCount: 1
   oauthClientId: radar_fitbit_connector
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 0.4.5
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
 
 radar_rest_sources_backend:
   _install: false
-  _chart_version: 0.4.6
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
   postgres:
@@ -298,7 +298,7 @@ radar_grafana:
 
 radar_jdbc_connector:
   _install: true
-  _chart_version: 0.4.0
+  _chart_version: 0.4.2
   _extra_timeout: 0
   replicaCount: 1
   sink:
@@ -309,7 +309,7 @@ radar_jdbc_connector:
 
 radar_gateway:
   _install: true
-  _chart_version: 0.2.6
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -317,7 +317,7 @@ radar_gateway:
 
 radar_backend_monitor:
   _install: false
-  _chart_version: 0.1.2
+  _chart_version: 0.1.3
   _extra_timeout: 0
   replicaCount: 1
   smtp:
@@ -329,7 +329,7 @@ radar_backend_monitor:
 
 radar_backend_stream:
   _install: false
-  _chart_version: 0.1.2
+  _chart_version: 0.1.3
   _extra_timeout: 0
   replicaCount: 1
 
@@ -337,7 +337,7 @@ radar_backend_stream:
 
 radar_integration:
   _install: false
-  _chart_version: 0.4.0
+  _chart_version: 0.4.1
   _extra_timeout: 0
   replicaCount: 1
   oauth_client_id: radar_redcap_integrator
@@ -377,7 +377,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
-  _chart_version: 0.2.4
+  _chart_version: 0.2.6
   _extra_timeout: 90
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.
@@ -386,7 +386,7 @@ radar_s3_connector:
 
 s3_proxy:
   _install: false
-  _chart_version: 0.1.3
+  _chart_version: 0.2.1
   _extra_timeout: 0
   replicaCount: 1
   target:
@@ -394,7 +394,7 @@ s3_proxy:
 
 radar_output:
   _install: true
-  _chart_version: 0.3.1
+  _chart_version: 0.3.3
   _extra_timeout: 0
   replicaCount: 1
   source:
@@ -413,7 +413,7 @@ radar_output:
 
 radar_upload_postgresql:
   _install: true
-  _chart_version: 11.1.24
+  _chart_version: 12.1.9
   _extra_timeout: 0
   image: # Check https://hub.docker.com/r/bitnami/postgresql/tags
     tag: 11.16.0
@@ -425,19 +425,19 @@ radar_upload_postgresql:
 
 radar_upload_connect_backend:
   _install: true
-  _chart_version: 0.2.3
+  _chart_version: 0.2.4
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_connect_frontend:
   _install: true
-  _chart_version: 0.2.3
+  _chart_version: 0.2.4
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_source_connector:
   _install: true
-  _chart_version: 0.2.2
+  _chart_version: 0.2.3
   _extra_timeout: 60
   replicaCount: 1
   s3Endpoint: http://minio:9000/
@@ -446,7 +446,7 @@ radar_upload_source_connector:
 
 ccSchemaRegistryProxy:
   _install: false
-  _chart_version: 0.2.3
+  _chart_version: 0.2.4
   _extra_timeout: 0
   externalName: schema-registry-domain
 
@@ -454,7 +454,7 @@ ccSchemaRegistryProxy:
 
 radar_push_endpoint:
   _install: false
-  _chart_version: 0.1.4
+  _chart_version: 0.1.5
   _extra_timeout: 180
   replicaCount: 1
   adminProperties: {}
@@ -465,7 +465,7 @@ radar_push_endpoint:
 
 radar_jdbc_connector_agg:
   _install: false
-  _chart_version: 0.4.1
+  _chart_version: 0.4.2
   _extra_timeout: 0
   replicaCount: 1
 
@@ -489,7 +489,7 @@ ksql_server:
 
 velero:
   _install: false
-  _chart_version: 0.1.0
+  _chart_version: 0.1.1
   _extra_timeout: 0
   objectStorageBackupReplicaCount: 1
   backup:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -155,7 +155,7 @@ catalog_server:
 
 radar_home:
   _install: true
-  _chart_version: 0.2.0
+  _chart_version: 0.2.1
   _extra_timeout: 0
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
@@ -179,7 +179,7 @@ postgresql:
 
 management_portal:
   _install: true
-  _chart_version: 1.1.0
+  _chart_version: 1.1.2
   _extra_timeout: 210
   replicaCount: 1  # should be 1
   postgres:
@@ -226,7 +226,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.2.0
+  _chart_version: 0.2.1
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer
@@ -236,20 +236,20 @@ radar_appserver:
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit or Garmin API integration.
 radar_fitbit_connector:
   _install: false
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 0
   replicaCount: 1
   oauthClientId: radar_fitbit_connector
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 1.1.0
+  _chart_version: 1.1.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_rest_sources_backend:
   _install: false
-  _chart_version: 1.1.0
+  _chart_version: 1.1.1
   _extra_timeout: 0
   replicaCount: 1
   postgres:
@@ -298,7 +298,7 @@ radar_grafana:
 
 radar_jdbc_connector:
   _install: true
-  _chart_version: 0.5.0
+  _chart_version: 0.5.1
   _extra_timeout: 0
   replicaCount: 1
   sink:
@@ -309,7 +309,7 @@ radar_jdbc_connector:
 
 radar_gateway:
   _install: true
-  _chart_version: 1.1.1
+  _chart_version: 1.1.2
   _extra_timeout: 0
   replicaCount: 1
 
@@ -317,7 +317,7 @@ radar_gateway:
 
 radar_backend_monitor:
   _install: false
-  _chart_version: 0.2.0
+  _chart_version: 0.2.1
   _extra_timeout: 0
   replicaCount: 1
   smtp:
@@ -329,7 +329,7 @@ radar_backend_monitor:
 
 radar_backend_stream:
   _install: false
-  _chart_version: 0.2.0
+  _chart_version: 0.2.1
   _extra_timeout: 0
   replicaCount: 1
 
@@ -337,7 +337,7 @@ radar_backend_stream:
 
 radar_integration:
   _install: false
-  _chart_version: 0.5.0
+  _chart_version: 0.5.1
   _extra_timeout: 0
   replicaCount: 1
   oauth_client_id: radar_redcap_integrator
@@ -377,7 +377,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 90
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.
@@ -386,7 +386,7 @@ radar_s3_connector:
 
 s3_proxy:
   _install: false
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 0
   replicaCount: 1
   target:
@@ -394,7 +394,7 @@ s3_proxy:
 
 radar_output:
   _install: true
-  _chart_version: 0.4.0
+  _chart_version: 0.4.1
   _extra_timeout: 0
   replicaCount: 1
   source:
@@ -425,19 +425,19 @@ radar_upload_postgresql:
 
 radar_upload_connect_backend:
   _install: true
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_connect_frontend:
   _install: true
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_source_connector:
   _install: true
-  _chart_version: 0.3.0
+  _chart_version: 0.3.1
   _extra_timeout: 60
   replicaCount: 1
   s3Endpoint: http://minio:9000/
@@ -454,7 +454,7 @@ ccSchemaRegistryProxy:
 
 radar_push_endpoint:
   _install: false
-  _chart_version: 0.2.1
+  _chart_version: 0.2.2
   _extra_timeout: 180
   replicaCount: 1
   adminProperties: {}
@@ -465,7 +465,7 @@ radar_push_endpoint:
 
 radar_jdbc_connector_agg:
   _install: false
-  _chart_version: 0.5.0
+  _chart_version: 0.5.1
   _extra_timeout: 0
   replicaCount: 1
 
@@ -489,7 +489,7 @@ ksql_server:
 
 velero:
   _install: false
-  _chart_version: 0.2.0
+  _chart_version: 0.2.1
   _extra_timeout: 0
   objectStorageBackupReplicaCount: 1
   backup:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -123,6 +123,7 @@ kratos:
 
 
   kratos:
+    # When installing, you must manually create a database named kratos in the postgresql database.
     development: false
 
     # -- Enables database migration
@@ -333,7 +334,7 @@ kratos:
       log:
         level: debug
         format: text
-        leak_sensitive_values: true
+        leak_sensitive_values: false
 
 kratos_ui:
   config:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -105,6 +105,249 @@ kafka_manager:
   _chart_version: 2.1.6
   _extra_timeout: 0
 
+# --------------------------------------------------------- 05-ory.yaml ---------------------------------------------------------
+
+kratos:
+  ingress:
+    admin:
+      enabled: true
+      className: "nginx"
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+    public:
+      enabled: true
+      className: "nginx"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$1
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+
+
+  kratos:
+    development: false
+
+    # -- Enables database migration
+    automigration:
+      enabled: true
+      # -- Configure the way to execute database migration. Possible values: job, initContainer
+      # When set to job, the migration will be executed as a job on release or upgrade.
+      # When set to initContainer, the migration will be executed when Kratos pod is created
+      # Defaults to job
+      type: job
+      # -- Ability to override the entrypoint of the automigration container
+      # (e.g. to source dynamic secrets or export environment dynamic variables)
+      customCommand: [ ]
+      # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand
+      # eg:
+      # - sleep 5;
+      #   - kratos
+      customArgs: [ ]
+      # -- resource requests and limits for the automigration initcontainer
+      resources: { }
+
+    # -- You can add multiple identity schemas here. You can pass JSON schema using `--set-file` Helm CLI argument.
+    identitySchemas:
+      "identity.user.schema.json": |
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "$id": "user",
+          "title": "user",
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "title": "E-Mail",
+                  "minLength": 5,
+                  "ory.sh/kratos": {
+                    "credentials": {
+                      "password": {
+                        "identifier": true
+                      },
+                      "totp": {
+                        "account_name": true
+                      }
+                    },
+                    "verification": {
+                      "via": "email"
+                    },
+                    "recovery": {
+                      "via": "email"
+                    }
+                  }
+                }
+              },
+              "required": [ "email" ]
+            }
+          },
+          "additionalProperties": false
+        }
+      "identity.default.schema.json": |
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "$id": "default",
+          "title": "user",
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "title": "E-Mail",
+                  "minLength": 5,
+                  "ory.sh/kratos": {
+                    "credentials": {
+                      "password": {
+                        "identifier": true
+                      },
+                      "totp": {
+                        "account_name": true
+                      }
+                    },
+                    "verification": {
+                      "via": "email"
+                    },
+                    "recovery": {
+                      "via": "email"
+                    }
+                  }
+                }
+              },
+              "required": [ "email" ]
+            }
+          },
+          "additionalProperties": false
+        }
+
+    # -- You can customize the emails Kratos is sending (also uncomment config.courier.template_override_path below)
+    emailTemplates:
+     emailTemplates:
+       recovery:
+         valid:
+           subject: Recover access to your account
+           body: |-
+             Hi, please recover access to your account by clicking the following link:
+             <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>
+           plainBody: |-
+             Hi, please recover access to your account by clicking the following link: {{ .RecoveryURL }}
+         invalid:
+           subject: Account access attempted
+           body: |-
+             Hi, you (or someone else) entered this email address when trying to recover access to an account.
+             However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
+           plainBody: |-
+             Hi, you (or someone else) entered this email address when trying to recover access to an account.
+       verification:
+         valid:
+           subject: Please verify your email address
+           body: |-
+             Hi, please verify your account by clicking the following link:
+             <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
+           plainBody: |-
+             Hi, please verify your account by clicking the following link: {{ .VerificationURL }}
+    #     invalid:
+    #       subject:
+    #       body:
+    #       plainBody:
+
+    config:
+
+      session:
+        # Defines how long a session is active. Once that lifespan has been reached, the user needs to sign in again.
+        lifespan: 24h
+
+        cookie:
+          ##-- If false, cookie is removed when the browser is closed --##
+          persistent: false
+
+      serve:
+        public:
+          cors:
+            enabled: true
+            allowed_methods:
+              - POST
+              - GET
+              - PUT
+              - PATCH
+              - DELETE
+            allowed_headers:
+              - Authorization
+              - Cookie
+              - Content-Type
+              - Accept
+            exposed_headers:
+              - Content-Type
+              - Set-Cookie
+              - Accept
+            allow_credentials: true
+
+      selfservice:
+        methods:
+          password:
+            config:
+              haveibeenpwned_enabled: true
+              max_breaches: 0
+              ignore_network_errors: false
+              min_password_length: 12
+              identifier_similarity_check_enabled: true
+            enabled: true
+          totp:
+            config:
+              issuer: Radar
+            enabled: true
+          link:
+            enabled: true
+
+        flows:
+          settings:
+            required_aal: highest_available
+
+          recovery:
+            enabled: true
+            use: link
+
+          verification:
+            enabled: false
+            use: link
+
+          registration:
+            after:
+              password:
+                hooks:
+                  - hook: session
+              oidc:
+                hooks:
+                  - hook: session
+
+      identity:
+        default_schema_id: user
+        schemas:
+          # identitySchemas:
+          - id: user
+            url: file:///etc/config/identity.user.schema.json
+
+      log:
+        level: debug
+        format: text
+        leak_sensitive_values: true
+
+kratos_ui:
+  config:
+    csrfCookieName: "radar_csrf"
+
+  ingress:
+    enabled: true
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+
+  kratosAdminUrl: "kratos-admin"
+
 # --------------------------------------------------------- 10-base.yaml ---------------------------------------------------------
 # Use letsencrypt to retrieve SSL certificates.
 cert_manager_letsencrypt:
@@ -243,7 +486,7 @@ radar_fitbit_connector:
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 1.1.2
+  _chart_version: 1.1.3
   _extra_timeout: 0
   replicaCount: 1
 

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -226,7 +226,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.1.6
+  _chart_version: 0.1.7
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -148,14 +148,14 @@ cp_schema_registry:
 
 catalog_server:
   _install: true
-  _chart_version: 0.5.0
+  _chart_version: 0.5.1
   _extra_timeout: 90
   replicaCount: 1
   schema_registry: http://cp-schema-registry:8081
 
 radar_home:
   _install: true
-  _chart_version: 0.2.1
+  _chart_version: 0.2.2
   _extra_timeout: 0
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
@@ -196,7 +196,7 @@ management_portal:
 
 app_config:
   _install: true
-  _chart_version: 1.1.0
+  _chart_version: 1.1.1
   _extra_timeout: 0
   replicaCount: 1
   jdbc:
@@ -204,7 +204,7 @@ app_config:
 
 app_config_frontend:
   _install: true
-  _chart_version: 1.1.0
+  _chart_version: 1.1.1
   _extra_timeout: 0
   replicaCount: 1
 
@@ -243,7 +243,7 @@ radar_fitbit_connector:
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 1.1.1
+  _chart_version: 1.1.2
   _extra_timeout: 0
   replicaCount: 1
 

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -56,7 +56,7 @@ cert_manager:
 # kubectl --context <my-context> apply --force-conflicts --server-side -f etc/kube-prometheus-stack/files/crds.yaml
 kube_prometheus_stack:
   _install: true
-  _chart_version: 0.4.1
+  _chart_version: 0.4.2
   _extra_timeout: 0
   kube-prometheus-stack:
     prometheus:
@@ -148,14 +148,14 @@ cp_schema_registry:
 
 catalog_server:
   _install: true
-  _chart_version: 0.4.6
+  _chart_version: 0.5.0
   _extra_timeout: 90
   replicaCount: 1
   schema_registry: http://cp-schema-registry:8081
 
 radar_home:
   _install: true
-  _chart_version: 0.1.3
+  _chart_version: 0.2.0
   _extra_timeout: 0
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
@@ -179,7 +179,7 @@ postgresql:
 
 management_portal:
   _install: true
-  _chart_version: 1.0.0
+  _chart_version: 1.1.0
   _extra_timeout: 210
   replicaCount: 1  # should be 1
   postgres:
@@ -196,7 +196,7 @@ management_portal:
 
 app_config:
   _install: true
-  _chart_version: 1.0.0
+  _chart_version: 1.1.0
   _extra_timeout: 0
   replicaCount: 1
   jdbc:
@@ -204,7 +204,7 @@ app_config:
 
 app_config_frontend:
   _install: true
-  _chart_version: 1.0.0
+  _chart_version: 1.1.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -226,7 +226,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.1.7
+  _chart_version: 0.2.0
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer
@@ -236,20 +236,20 @@ radar_appserver:
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit or Garmin API integration.
 radar_fitbit_connector:
   _install: false
-  _chart_version: 0.2.3
+  _chart_version: 0.3.0
   _extra_timeout: 0
   replicaCount: 1
   oauthClientId: radar_fitbit_connector
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 1.0.0
+  _chart_version: 1.1.0
   _extra_timeout: 0
   replicaCount: 1
 
 radar_rest_sources_backend:
   _install: false
-  _chart_version: 1.0.0
+  _chart_version: 1.1.0
   _extra_timeout: 0
   replicaCount: 1
   postgres:
@@ -298,7 +298,7 @@ radar_grafana:
 
 radar_jdbc_connector:
   _install: true
-  _chart_version: 0.4.2
+  _chart_version: 0.5.0
   _extra_timeout: 0
   replicaCount: 1
   sink:
@@ -309,7 +309,7 @@ radar_jdbc_connector:
 
 radar_gateway:
   _install: true
-  _chart_version: 1.0.0
+  _chart_version: 1.1.1
   _extra_timeout: 0
   replicaCount: 1
 
@@ -317,7 +317,7 @@ radar_gateway:
 
 radar_backend_monitor:
   _install: false
-  _chart_version: 0.1.3
+  _chart_version: 0.2.0
   _extra_timeout: 0
   replicaCount: 1
   smtp:
@@ -329,7 +329,7 @@ radar_backend_monitor:
 
 radar_backend_stream:
   _install: false
-  _chart_version: 0.1.3
+  _chart_version: 0.2.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -337,7 +337,7 @@ radar_backend_stream:
 
 radar_integration:
   _install: false
-  _chart_version: 0.4.1
+  _chart_version: 0.5.0
   _extra_timeout: 0
   replicaCount: 1
   oauth_client_id: radar_redcap_integrator
@@ -377,7 +377,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
-  _chart_version: 0.2.6
+  _chart_version: 0.3.0
   _extra_timeout: 90
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.
@@ -386,7 +386,7 @@ radar_s3_connector:
 
 s3_proxy:
   _install: false
-  _chart_version: 0.2.1
+  _chart_version: 0.3.0
   _extra_timeout: 0
   replicaCount: 1
   target:
@@ -394,7 +394,7 @@ s3_proxy:
 
 radar_output:
   _install: true
-  _chart_version: 0.3.3
+  _chart_version: 0.4.0
   _extra_timeout: 0
   replicaCount: 1
   source:
@@ -425,19 +425,19 @@ radar_upload_postgresql:
 
 radar_upload_connect_backend:
   _install: true
-  _chart_version: 0.2.4
+  _chart_version: 0.3.0
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_connect_frontend:
   _install: true
-  _chart_version: 0.2.4
+  _chart_version: 0.3.0
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_source_connector:
   _install: true
-  _chart_version: 0.2.3
+  _chart_version: 0.3.0
   _extra_timeout: 60
   replicaCount: 1
   s3Endpoint: http://minio:9000/
@@ -454,7 +454,7 @@ ccSchemaRegistryProxy:
 
 radar_push_endpoint:
   _install: false
-  _chart_version: 0.1.5
+  _chart_version: 0.2.1
   _extra_timeout: 180
   replicaCount: 1
   adminProperties: {}
@@ -465,7 +465,7 @@ radar_push_endpoint:
 
 radar_jdbc_connector_agg:
   _install: false
-  _chart_version: 0.4.2
+  _chart_version: 0.5.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -489,7 +489,7 @@ ksql_server:
 
 velero:
   _install: false
-  _chart_version: 0.1.1
+  _chart_version: 0.2.0
   _extra_timeout: 0
   objectStorageBackupReplicaCount: 1
   backup:

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -45,10 +45,12 @@ releases:
         value: {{ .Values.maintainer_email }}
       - name: graylog.ingress.hosts
         values: [graylog.{{ .Values.server_name }}]
+        {{- if .Values.graylog.ingress.tls }}
       - name: graylog.ingress.tls[0].secretName
         value: radar-base-tls
       - name: graylog.ingress.tls[0].hosts
         values: ["graylog.{{ .Values.server_name }}"]
+        {{ end }}
 
   - name: fluent-bit
     namespace: graylog
@@ -79,24 +81,30 @@ releases:
         value: {{ .Values.server_name }}
       - name: kube-prometheus-stack.prometheus.ingress.hosts
         values: ["prometheus.{{ .Values.server_name }}"]
+        {{- if .Values.kube_prometheus_stack.ingress.tls }}
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].secretName
         value: radar-base-tls-prometheus
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].hosts
         values: ["prometheus.{{ .Values.server_name }}"]
+        {{ end }}
 
       - name: kube-prometheus-stack.alertmanager.ingress.hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
+        {{- if .Values.kube-prometheus-stack.alertmanager.ingress.tls }}
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].secretName
         value: radar-base-tls-alertmanager
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
+        {{ end }}
 
       - name: kube-prometheus-stack.grafana.ingress.hosts
         values: ["grafana.{{ .Values.server_name }}"]
+        {{- if .Values.kube-prometheus-stack.grafana.ingress.tls }}
       - name: kube-prometheus-stack.grafana.ingress.tls[0].secretName
         value: radar-base-tls-grafana
       - name: kube-prometheus-stack.grafana.ingress.tls[0].hosts
         values: ["grafana.{{ .Values.server_name }}"]
+        {{ end }}
 
   - name: cert-manager
     namespace: cert-manager

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -90,7 +90,7 @@ releases:
 
       - name: kube-prometheus-stack.alertmanager.ingress.hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
-        {{- if .Values.kube-prometheus-stack.alertmanager.ingress.tls }}
+        {{- if .Values.kube_prometheus_stack.alertmanager.ingress.tls }}
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].secretName
         value: radar-base-tls-alertmanager
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].hosts
@@ -99,7 +99,7 @@ releases:
 
       - name: kube-prometheus-stack.grafana.ingress.hosts
         values: ["grafana.{{ .Values.server_name }}"]
-        {{- if .Values.kube-prometheus-stack.grafana.ingress.tls }}
+        {{- if .Values.kube_prometheus_stack.grafana.ingress.tls }}
       - name: kube-prometheus-stack.grafana.ingress.tls[0].secretName
         value: radar-base-tls-grafana
       - name: kube-prometheus-stack.grafana.ingress.tls[0].hosts

--- a/helmfile.d/00-init.yaml
+++ b/helmfile.d/00-init.yaml
@@ -45,7 +45,7 @@ releases:
         value: {{ .Values.maintainer_email }}
       - name: graylog.ingress.hosts
         values: [graylog.{{ .Values.server_name }}]
-        {{- if .Values.graylog.ingress.tls }}
+        {{- if .Values.graylog.graylog.ingress.tls }}
       - name: graylog.ingress.tls[0].secretName
         value: radar-base-tls
       - name: graylog.ingress.tls[0].hosts
@@ -81,7 +81,7 @@ releases:
         value: {{ .Values.server_name }}
       - name: kube-prometheus-stack.prometheus.ingress.hosts
         values: ["prometheus.{{ .Values.server_name }}"]
-        {{- if .Values.kube_prometheus_stack.ingress.tls }}
+        {{- if index .Values "kube_prometheus_stack" "kube-prometheus-stack.prometheus.ingress.tls" }}
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].secretName
         value: radar-base-tls-prometheus
       - name: kube-prometheus-stack.prometheus.ingress.tls[0].hosts
@@ -90,7 +90,7 @@ releases:
 
       - name: kube-prometheus-stack.alertmanager.ingress.hosts
         values: ["alertmanager.{{ .Values.server_name }}"]
-        {{- if .Values.kube_prometheus_stack.alertmanager.ingress.tls }}
+        {{- if index .Values "kube_prometheus_stack" "kube-prometheus-stack.alertmanager.ingress.tls" }}
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].secretName
         value: radar-base-tls-alertmanager
       - name: kube-prometheus-stack.alertmanager.ingress.tls[0].hosts
@@ -99,7 +99,7 @@ releases:
 
       - name: kube-prometheus-stack.grafana.ingress.hosts
         values: ["grafana.{{ .Values.server_name }}"]
-        {{- if .Values.kube_prometheus_stack.grafana.ingress.tls }}
+        {{- if index .Values "kube_prometheus_stack" "kube-prometheus-stack.grafana.ingress.tls" }}
       - name: kube-prometheus-stack.grafana.ingress.tls[0].secretName
         value: radar-base-tls-grafana
       - name: kube-prometheus-stack.grafana.ingress.tls[0].hosts

--- a/helmfile.d/05-ory.yaml
+++ b/helmfile.d/05-ory.yaml
@@ -1,0 +1,17 @@
+bases:
+  - ../environments.yaml
+
+---
+
+helmDefaults:
+  kubeContext: {{ .Values.kubeContext }}
+
+releases:
+  - name: kratos
+    chart: ory/kratos
+    values:
+      - {{ .Values.kratos | toYaml | indent 8 | trim }}
+  - name: kratos-selfservice-ui-node
+    chart: ory/kratos-selfservice-ui-node
+    values:
+      - {{ .Values.kratos_ui | toYaml | indent 8 | trim }}

--- a/helmfile.d/10-base.yaml
+++ b/helmfile.d/10-base.yaml
@@ -57,10 +57,12 @@ releases:
         value: "{{ .Values.server_name }}"
       - name: ingress.hosts[0].paths
         values: ["/schema/?(.*)"]
+        {{- if .Values.cp_schema_registry.ingress.tls }}
       - name: ingress.tls[0].secretName
         value: radar-base-tls
       - name: ingress.tls[0].hosts
         values: ["{{ .Values.server_name }}"]
+        {{ end }}
 
   - name: catalog-server
     chart: radar/catalog-server

--- a/helmfile.d/10-managementportal.yaml
+++ b/helmfile.d/10-managementportal.yaml
@@ -27,6 +27,8 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      - name: ingress_rate_limited.hosts
+        values: [{{ .Values.server_name }}]
       - name: server_name
         value: {{ .Values.server_name }}
       - name: oauth_clients.radar_redcap_integrator.enable

--- a/helmfile.d/20-grafana.yaml
+++ b/helmfile.d/20-grafana.yaml
@@ -48,10 +48,12 @@ releases:
         values: ["dashboard.{{ .Values.server_name }}"]
       - name: "grafana\\.ini.server.root_url"
         value: "https://dashboard.{{ .Values.server_name }}/"
+        {{- if .Values.radar_grafana.ingress.tls }}
       - name: ingress.tls[0].secretName
         value: radar-base-tls-dashboard
       - name: ingress.tls[0].hosts
         values: ["dashboard.{{ .Values.server_name }}"]
+        {{ end }}
       - name: "grafana\\.ini.metrics.basic_auth_username"
         value: {{ .Values.grafana_metrics_username }}
       - name: "grafana\\.ini.metrics.basic_auth_password"

--- a/helmfile.d/40-realtime-dashboard.yaml
+++ b/helmfile.d/40-realtime-dashboard.yaml
@@ -18,7 +18,7 @@ releases:
     set:
       - name: kafka_num_brokers
         value: {{ .Values.kafka_num_brokers }}
-      - name: jdbc.username
+      - name: jdbc.user
         value: {{ .Values.timescaledb_username }}
       - name: jdbc.password
         value: {{ .Values.timescaledb_password }}


### PR DESCRIPTION
**Description of the change**

Nesting was wrongly configured in the 00-init file, causing `tls` values not te be templated.

I changed the nesting. To do this it was needed to use `index` as the `kube-prometheus-stack` name uses hyphen.

See: https://stackoverflow.com/a/63863410

**Benefits**

We can disable tls using the helm values

**Possible drawbacks**

Added complexity due to the index function.