### PR TITLE
[Github Action] Check all secrets are replaced by bin/generate-secrets

### DIFF
--- a/.github/workflows/check_secret_replacement.yaml
+++ b/.github/workflows/check_secret_replacement.yaml
@@ -1,0 +1,34 @@
+name: Check missed fields during secret generation
+
+on:
+  pull_request:
+    branches:
+      - '**' # This will trigger the workflow for any PR branch
+
+jobs:
+  check_secrets:
+         runs-on: ubuntu-latest
+
+         steps:
+           - name: Checkout repository
+             uses: actions/checkout@v2
+
+           - name: Install yq
+             uses: dcarbone/install-yq-action@v1.1.1
+
+           - name: Run bin/generate-secrets
+             run: bin/generate-secrets
+
+           - name: Check all "secret" fields are replaced
+             run: |
+               mistakes=$(yq e '.. | select(. == "secret") | {(path | join(".")): .}' etc/secrets.yaml); \
+               num_of_mistakes=$(echo $mistakes | sed '/^$/d' | wc -l); \
+               if (( $num_of_mistakes > 0 )); then \
+                echo "Not all 'secret' fields were replaced by the bin/generate-secrets script."; \
+                echo "Please make sure to cover the following fields with an 'insert_secret' entry:"; \
+                echo $mistakes; \
+                exit 1; \
+               else \
+                echo "Perfect! All 'secret' fields were replaced by the bin/generate-secrets script."; \
+                exit 0; \
+               fi;

--- a/bin/generate-secrets
+++ b/bin/generate-secrets
@@ -33,25 +33,17 @@ fi
 
 insert_secret() {
   localSecret="${secret:-$(generate_secret)}"
+  # For any group of yaml paths passed add the same (!) password.
   for key in "$@"; do
     localSecret="$localSecret" yq -i "$key = strenv(localSecret)" etc/secrets.yaml
   done
+  # Do not remove this 'secret=' line! It ensures that subsequent replacements get a unique password.
+  secret=
 }
 
-insert_secret ".mongodb.auth.replicaSetKey"
-insert_secret ".mongodb.auth.rootPassword"
-insert_secret ".mongodb.auth.passwords[0]"
+# -- Groups of shared passwords
 
-insert_secret ".graylog.graylog.rootPassword"
-insert_secret ".kube_prometheus_stack.kube-prometheus-stack.grafana.adminPassword"
-
-nginx_auth_password=$(generate_secret)
-secret="thehyve:$(echo $nginx_auth_password | openssl passwd -apr1 -stdin)" insert_secret ".kube_prometheus_stack.nginx_auth"
-comment="username: thehyve, password: $nginx_auth_password" yq -i ".kube_prometheus_stack.nginx_auth line_comment |= strenv(comment)" etc/secrets.yaml
-
-insert_secret ".kafka_manager.basicAuth.password"
-
-# Shared postgresql secret
+# Management portal postgres database
 insert_secret \
   ".postgresql.global.postgresql.auth.postgresPassword" \
   ".postgresql.auth.replicationPassword" \
@@ -59,28 +51,21 @@ insert_secret \
   ".app_config.jdbc.password" \
   ".radar_rest_sources_backend.postgres.password"
 
-insert_secret ".management_portal.managementportal.common_admin_password"
-insert_secret ".management_portal.managementportal.frontend_client_secret"
-insert_secret ".management_portal.oauth_clients.radar_upload_backend.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_upload_connect.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_rest_sources_auth_backend.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_redcap_integrator.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_fitbit_connector.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_appconfig.client_secret"
-insert_secret ".management_portal.oauth_clients.radar_push_endpoint.client_secret"
-
+# Appserver postgres database
 insert_secret \
   ".radar_appserver_postgresql.global.postgresql.auth.postgresPassword" \
   ".radar_appserver_postgresql.auth.replicationPassword" \
   ".radar_appserver.postgres.password"
 
-insert_secret ".timescaledb_password"
-insert_secret ".grafana_password"
-insert_secret ".grafana_metrics_password"
+# --
 
-insert_secret ".s3_access_key"
-insert_secret ".s3_secret_key"
+# The NGINX password for prometheus follows a pattern different from others.
+nginx_auth_password=$(generate_secret)
+secret="thehyve:$(echo $nginx_auth_password | openssl passwd -apr1 -stdin)" insert_secret ".kube_prometheus_stack.nginx_auth"
+comment="username: thehyve, password: $nginx_auth_password" yq -i ".kube_prometheus_stack.nginx_auth line_comment |= strenv(comment)" etc/secrets.yaml
 
-insert_secret ".radar_upload_postgres_password"
-
-echo "Passwords and secrets have been generated successfully."
+# Generate secrets for all remaining fields with value 'secret'.
+replacements=$(yq e '.. | select(. == "secret") | [(path | "."+join("."))] | join(" ")' etc/secrets.yaml);
+for key in $replacements; do
+  insert_secret $key
+done

--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -1,6 +1,6 @@
 # NOTE:
-# - properties equal to 'secret' will be replaced by the bin/generate-secrets script
-# - properties equal to 'change_me' should be replaced manually (externally provided secrets)
+# - properties equal to 'secret' will be replaced by the bin/generate-secrets script.
+# - properties equal to 'change_me' are externally provided secrets that should be replaced manually.
 
 # --------------------------------------------------------- 00-init.yaml ---------------------------------------------------------
 mongodb:
@@ -47,12 +47,12 @@ kafka_manager:
 # --------------------------------------------------------- 10-base.yaml ---------------------------------------------------------
 confluent_cloud:
   cc:
-    bootstrapServerurl: confluentBootstrapServers
-    schemaRegistryUrl: confluentSchemaRegistryUrl
-    apiKey: ccApikey
-    apiSecret: ccApiSecret
-    schemaRegistryApiKey: srApiKey
-    schemaRegistryApiSecret: srApiSecret
+    bootstrapServerurl: change_me
+    schemaRegistryUrl: change_me
+    apiKey: change_me
+    apiSecret: change_me
+    schemaRegistryApiKey: change_me
+    schemaRegistryApiSecret: change_me
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
 postgresql:
@@ -146,8 +146,8 @@ radar_integration:
 # --------------------------------------------------------- 20-s3-connector.yaml ---------------------------------------------------------
 # The access keys and secret keys of object storage services should match.
 # If AWS S3 is used as a storage medium instead of minio, then fill in those.
-s3_access_key: secret
-s3_secret_key: secret
+s3_access_key: change_me
+s3_secret_key: change_me
 
 # --------------------------------------------------------- 20-upload.yaml ---------------------------------------------------------
 radar_upload_postgres_password: secret

--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -1,3 +1,7 @@
+# NOTE:
+# - properties equal to 'secret' will be replaced by the bin/generate-secrets script
+# - properties equal to 'change_me' should be replaced manually (externally provided secrets)
+
 # --------------------------------------------------------- 00-init.yaml ---------------------------------------------------------
 mongodb:
   auth:
@@ -87,7 +91,7 @@ management_portal:
     radar_push_endpoint:
       client_secret: secret
   smtp:
-    password: secret
+    password: change_me
 
 app_config:
   jdbc:
@@ -111,11 +115,11 @@ radar_appserver:
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit or Garmin API integration.
 # Get a Fitbit API client by registering a server application
 # at https://dev.fitbit.com/manage/
-fitbit_api_client: "secret"
-fitbit_api_secret: "secret"
+fitbit_api_client: change_me
+fitbit_api_secret: change_me
 
-oura_api_client: "secret"
-oura_api_secret: "secret"
+oura_api_client: change_me
+oura_api_secret: change_me
 
 radar_rest_sources_backend:
   postgres:
@@ -153,19 +157,19 @@ radar_upload_postgres_password: secret
 # https://developer.garmin.com/gc-developer-program/overview/
 radar_push_endpoint:
   garmin:
-    consumerKey: "secret"
-    consumerSecret: "secret"
+    consumerKey: change_me
+    consumerSecret: change_me
 
 # --------------------------------------------------------- 99-velero.yaml ---------------------------------------------------------
 
 velero:
   backup:
-    accessKey: secret
-    secretKey: secret
+    accessKey: change_me
+    secretKey: change_me
   velero:
     credentials:
       secretContents:
         cloud: |
           [default]
-          aws_access_key_id=secret
-          aws_secret_access_key=secret
+          aws_access_key_id=change_me
+          aws_secret_access_key=change_me


### PR DESCRIPTION
When new secret placeholders are defined in _base-secrets.yaml_ the bin/generate-secrets script (that should replace secret placeholders with randomized values) is sometimes not updated accordingly. This will result in the use of the word _secret_ as a weak password.

This PR will implement a check on the occurrence of the word _secret_ in the _secrets.yaml_ file left after running the bin/generate-secrets script. If detect this will cause the action to fail with a message on which secrets to update. 

This PR also updates the _generate-secrets_ script to replace any field with value `secret` with a password.

Example output:

```
Not all 'secret' fields were replaced by bin/generate-secrets script. Please make sure to cover the following fields with a 'insert_secret' entry: 
management_portal.smtp.password: secret
fitbit_api_client: "secret"
fitbit_api_secret: "secret"
oura_api_client: "secret"
oura_api_secret: "secret"
radar_push_endpoint.garmin.consumerKey: "secret"
radar_push_endpoint.garmin.consumerSecret: "secret"
velero.backup.accessKey: secret
velero.backup.secretKey: secret
```
