### PR TITLE
[radar-s3-connector] Pass kafka_num_brokers global variable to helm chart

### DIFF
--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -45,6 +45,8 @@ releases:
       - {{ .Values.radar_s3_connector | toYaml | indent 8 | trim }}
       - {{ .Values.confluent_cloud | toYaml | indent 8 | trim }}
     set:
+      - name: kafka_num_brokers
+        value: {{ .Values.kafka_num_brokers }}
       - name: cc.enabled
         value: {{ .Values.confluent_cloud.enabled }}
       - name: bucketAccessKey


### PR DESCRIPTION
The _kafka_num_brokers_ global helmfile variable was not passed to the helm chart of radar-s3 connector. This will cause the radar-s3 connector to error out when this global variable is changed. This PR fixes that.
