### PR TITLE
[RADAR-Appserver] Enable notifications via email

### DIFF
--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -93,6 +93,7 @@ management_portal:
     radar_data_dashboard_backend:
       client_secret: secret
   smtp:
+    username: change_me
     password: change_me
 
 app_config:

--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -112,6 +112,9 @@ radar_appserver_postgresql:
 radar_appserver:
   postgres:
     password: secret
+  smtp:
+    username: change_me
+    password: change_me
 
 # --------------------------------------------------------- 20-fitbit.yaml ---------------------------------------------------------
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit or Garmin API integration.

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -251,6 +251,9 @@ radar_appserver:
   replicaCount: 1
   managementportal_resource_name: res_AppServer
   public_key_endpoints: []
+  smtp:
+    enabled: false
+    host: localhost
 
 # --------------------------------------------------------- 20-fitbit.yaml ---------------------------------------------------------
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit, Garmin, or Oura API integration.

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -194,9 +194,12 @@ management_portal:
     oauth_checking_key_aliases_0: radarbase-managementportal-ec
     oauth_checking_key_aliases_1: selfsigned
   smtp:
-    username: secret
-    password: secret
-    host: localhost
+    enabled: true
+    host: smtp
+    port: 25
+    from: noreply@example.com
+    starttls: false
+    auth: true
 
 kratos:
   _install: true
@@ -253,7 +256,11 @@ radar_appserver:
   public_key_endpoints: []
   smtp:
     enabled: false # -- set to true, if sending of notifications via email should be enabled.
-    host: localhost
+    host: smtp
+    port: 25
+    from: noreply@example.com
+    starttls: false
+    auth: true
 
 # --------------------------------------------------------- 20-fitbit.yaml ---------------------------------------------------------
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit, Garmin, or Oura API integration.

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -252,7 +252,7 @@ radar_appserver:
   managementportal_resource_name: res_AppServer
   public_key_endpoints: []
   smtp:
-    enabled: false
+    enabled: false # -- set to true, if sending of notifications via email should be enabled.
     host: localhost
 
 # --------------------------------------------------------- 20-fitbit.yaml ---------------------------------------------------------


### PR DESCRIPTION
**Description of the change**

This PR will pass SMTP connection credentials to the Appserver application. When value `radar_appserver.smtp.enabled=true`, Appserver will send notifications via email alongside push notifications.

**Note**

This feature depends on a new version of Appserver that is not yet available. The version bump will happen when new app version exists.
