### PR TITLE
[Minio] Correctly generate and register the Minio admin user credentials

### DIFF
--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -146,6 +146,11 @@ radar_integration:
   #      project_name: RADAR-BASE
 
 # --------------------------------------------------------- 20-s3-connector.yaml ---------------------------------------------------------
+
+minio:
+  admin_user: admin
+  admin_password: secret
+
 # The access keys and secret keys of object storage services should match.
 # If AWS S3 is used as a storage medium instead of minio, then fill in those.
 s3_access_key: change_me

--- a/helmfile.d/20-s3.yaml
+++ b/helmfile.d/20-s3.yaml
@@ -31,9 +31,9 @@ releases:
       - name: apiIngress.hostname
         value: "api.s3.{{ .Values.server_name }}"
       - name: auth.rootUser
-        value: {{ dig "auth" "rootUser" (dig "accessKey" .Values.s3_access_key .Values.minio) .Values.minio }}
+        value: {{ .Values.minio.admin_user }}
       - name: auth.rootPassword
-        value: {{ dig "auth" "rootPassword" (dig "secretKey" .Values.s3_secret_key .Values.minio) .Values.minio }}
+        value: {{ .Values.minio.admin_password }}
 
   - name: radar-s3-connector
     chart: radar/radar-s3-connector


### PR DESCRIPTION
I think that the credentials for the admin user in the Minio UI had problems:

- Were replaced by the key/secret S3 credentials used to upload data when no alternate password provided. This should never happen in my opinion. We should always use a dedicated admin account.
- Since the key/secret are 'external' secrets the generate-secrets script did not generate a random password for the admin user.

This PR will:
- introduce auto-generation of admin username/password random secrets 
- clarify the name of the UI admin user to `adminUser` and `adminPassword`. I think that `auth.rootUser` and `auth.rootPassword` is not clear enough to signify that this is the account to use in the UI.