### PR TITLE
[radar-rest-sources-authorizer] Add missing authUrl value

### DIFF
--- a/helmfile.d/20-fitbit.yaml
+++ b/helmfile.d/20-fitbit.yaml
@@ -41,6 +41,8 @@ releases:
         values: [{{ .Values.server_name }}]
       - name: serverName
         value: {{ .Values.server_name }}
+      - name: authUrl
+        value: {{ .Values.server_name }}/managementportal/oauth
 
   - name: radar-rest-sources-backend
     chart: radar/radar-rest-sources-backend


### PR DESCRIPTION
Setting of this values was missing from helmfile.