### PR TITLE
Export and import docker images from the cache

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,9 +34,6 @@ jobs:
           rm -rf ./.??* || true
           rm -rf /var/tmp/images || true
           ls -la ./
-          mkdir -p /var/tmp/images
-          for ref in `sudo k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do sudo k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref || true; done
-          /usr/local/bin/k3s-uninstall.sh
 
       - uses: actions/checkout@v3
 
@@ -62,12 +59,15 @@ jobs:
         run: |
           helmfile template
 
-      - name: Install K3S
+      - name: Reinstall K3S
         env:
           INSTALL_K3S_VERSION: ${{ matrix.K3S_VERSION }}
           INSTALL_K3S_SYMLINK: "skip"
           K3S_KUBECONFIG_MODE: "644"
         run: |
+          mkdir -p /var/tmp/images
+          for ref in `sudo k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do sudo k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref || true; done
+          /usr/local/bin/k3s-uninstall.sh        
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
           cd /var/tmp/images 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,7 +32,10 @@ jobs:
           ls -la ./
           rm -rf ./* || true
           rm -rf ./.??* || true
+          rm -rf /opt/images || true
           ls -la ./
+          mkdir -p /opt/images
+          for ref in `k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do k3s ctr images export /opt/images/`openssl rand -hex 10`.tar $ref; done
           /usr/local/bin/k3s-uninstall.sh
 
       - uses: actions/checkout@v3
@@ -67,6 +70,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+          ls -1 /opt/images | xargs -L1 k3s ctr images import
 
       - name: Install RADAR-Kubernetes
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,8 +34,8 @@ jobs:
           rm -rf ./.??* || true
           rm -rf /opt/images || true
           ls -la ./
-          mkdir -p /opt/images
-          for ref in `k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do k3s ctr images export /opt/images/`openssl rand -hex 10`.tar $ref; done
+          mkdir -p /var/tmp/images
+          for ref in `k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref; done
           /usr/local/bin/k3s-uninstall.sh
 
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          ls -1 /opt/images | xargs -L1 k3s ctr images import
+          ls -1 /var/tmp/images | xargs -L1 k3s ctr images import
 
       - name: Install RADAR-Kubernetes
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,10 +32,10 @@ jobs:
           ls -la ./
           rm -rf ./* || true
           rm -rf ./.??* || true
-          rm -rf /opt/images || true
+          rm -rf /var/tmp/images || true
           ls -la ./
           mkdir -p /var/tmp/images
-          for ref in `k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref; done
+          for ref in `sudo k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do sudo k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref; done
           /usr/local/bin/k3s-uninstall.sh
 
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          ls -1 /var/tmp/images | xargs -L1 k3s ctr images import
+          ls -1 /var/tmp/images | xargs -L1 sudo k3s ctr images import
 
       - name: Install RADAR-Kubernetes
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,7 @@ jobs:
           rm -rf /var/tmp/images || true
           ls -la ./
           mkdir -p /var/tmp/images
-          for ref in `sudo k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do sudo k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref; done
+          for ref in `sudo k3s ctr images ls | \grep -oE "^\S+" | sort -u` ; do sudo k3s ctr images export /var/tmp/images/`openssl rand -hex 10`.tar $ref || true; done
           /usr/local/bin/k3s-uninstall.sh
 
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          ls -1 /var/tmp/images | xargs -L1 sudo k3s ctr images import
+          ls -1 /var/tmp/images | xargs -L1 sudo k3s ctr images import || true
 
       - name: Install RADAR-Kubernetes
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -70,7 +70,9 @@ jobs:
         run: |
           curl -sfL https://get.k3s.io | sh -s - --disable traefik --disable-helm-controller
           cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          ls -1 /var/tmp/images | xargs -L1 sudo k3s ctr images import || true
+          cd /var/tmp/images 
+          ls -1 | xargs -L1 sudo k3s ctr images import || true
+          cd -
 
       - name: Install RADAR-Kubernetes
         env:


### PR DESCRIPTION
This PR tries to export the images before k3s is being removed and then import them when k3s is installed again so there wouldn't be a need to pull images as often.