### PR TITLE
[nginx-ingress] Impl. option to disable TLS termination

### DIFF
--- a/environments.yaml.tmpl
+++ b/environments.yaml.tmpl
@@ -1,10 +1,13 @@
 environments:
- default:
-   values:
-   - ../etc/base.yaml
-   - ../etc/production.yaml
-   - ../etc/production.yaml.gotmpl
-   - ../etc/secrets.yaml
+  default:
+    values:
+      - ../etc/base.yaml
+      - ../etc/production.yaml
+      - ../etc/production.yaml.gotmpl
+      - ../etc/secrets.yaml
+    {{ if not .Values.enable_tls }}
+      - ../mods/disable_tls.yaml
+    {{ end }}
 
 ---
 

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -4,12 +4,16 @@ atomicInstall: true
 base_timeout: 90
 # Context that you use in kubectl to access the Kubernetes cluster. Will be translated to `helm --kube-context <context_name>`
 kubeContext: default
-# Domain name that RADAR-Base installation will be acessible from
+# Domain name that RADAR-Base installation will be accessible from
 server_name: example.com
-# This email address will be used to notify for SSL certifcate expiration
+# This email address will be used to notify for SSL certificate expiration
 maintainer_email: MAINTAINER_EMAIL@example.com
 # Number of Kafka pods that will be installed
 kafka_num_brokers: 3
+# Enable TLS redirection and retrieval of Let's Encrypt certificates.
+# Can be disabled when TLS termination is handled upstream of the on-cluster Nginx reverse proxy.
+enable_tls: true
+
 
 # --------------------------------------------------------- 00-init.yaml ---------------------------------------------------------
 

--- a/mods/disable_tls.yaml
+++ b/mods/disable_tls.yaml
@@ -1,0 +1,8 @@
+cert_manager:
+  _install: false
+cert_manager_letsencrypt:
+  _install: false
+nginx_ingress:
+  controller:
+    config:
+      ssl-redirect: "false"


### PR DESCRIPTION
# Problem
When TLS termination is handled upstream, nginx-ingress should not handle TLS terminiation

# Solution
This PR will:
- Disable redirect to port 443 by the Nginx reverse proxy.
- Inactivate installation of cert-manager and cert-manager-letsencrypt