### PR TITLE
Impl. helmfile modifications for local development and testing

### DIFF
--- a/.github/ci_config/k3d-config.yaml
+++ b/.github/ci_config/k3d-config.yaml
@@ -1,0 +1,30 @@
+# See:
+# - https://github.com/k3d-io/k3d/issues/19#issuecomment-1967513596
+# - https://github.com/ligfx/k3d-registry-dockerd
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+volumes:
+  - volume: $HOME/k3d-containerd:/var/lib/rancher/k3s/agent/containerd/
+    nodeFilters:
+      - server:0
+registries:
+  create:
+    image: ligfx/k3d-registry-dockerd:v0.5
+    proxy:
+      remoteURL: "*"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+options:
+  k3s:
+    extraArgs:
+      - arg: --disable=helm-controller
+        nodeFilters:
+          - server:*
+      - arg: --disable=traefik
+        nodeFilters:
+          - server:*
+# Same as CLI parameter `--port '80:80@loadbalancer'`
+#ports:
+#  - port: 80:80
+#    nodeFilters:
+#      - loadbalancer

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The Kubernetes stack of RADAR-base platform.
 - [Volume expansion](#volume-expansion)
 - [Uninstall](#uninstall)
 - [Update charts](#update-charts)
+- [Development automation](#development-automation)
 - [Feedback and Contributions](#feedback-and-contributions)
 
 <!-- TOC end -->
@@ -556,6 +557,43 @@ To find any updates to the Helm charts that are listed in the repository, run
 ```shell
 bin/chart-updates
 ```
+
+## Development automation
+
+This repository can be used for development automation for instance on a k3s or k3d (dockerized k3s) cluster. The example below shows how to deploy on a k3d cluster.
+
+1. Install k3d (see [here](https://github.com/k3d-io/k3d#get))
+2. Create a k3d cluster that is configured to run RADAR-base
+
+```shell
+k3d cluster create my-test-cluster --port '80:80@loadbalancer' --config=.github/ci_config/k3d-config.yaml
+```
+
+This example creates a cluster named `my-test-cluster` with a load balancer that forwards local port 80 to the cluster. The
+configuration file `.github/ci_config/k3d-config.yaml` is used to configure the cluster. This cluster will be accessible
+in _kubectl_ with context name _k3d-my-test-cluster_.
+
+3. Initialize the RADAR-Kubernetes deployment. Run:
+
+```shell
+./bin/init
+```
+
+4. In file _etc/production.yaml_:
+
+- set _kubeContext_ to _k3d-my-test-cluster_
+- set _dev_deployment_ to _true_
+- (optional) enable/disable components as needed with the __install_ fields
+
+5. Install RADAR-Kubernetes on the k3d cluster:
+
+```shell
+helmfile sync
+```
+
+When installation is complete, you can access the applications at `http://localhost`.
+
+
 
 ## Feedback and Contributions
 

--- a/environments.yaml.tmpl
+++ b/environments.yaml.tmpl
@@ -8,6 +8,17 @@ environments:
     {{ if not .Values.enable_tls }}
       - ../mods/disable_tls.yaml
     {{ end }}
+    {{ if not .Values.enable_logging_monitoring }}
+      - ../mods/disable_monitoring_logging.yaml
+    {{ end }}
+    {{ if .Values.dev_deployment }}
+      - ../mods/disable_tls.yaml
+      - ../mods/disable_monitoring_logging.yaml
+      - ../mods/localdev.yaml
+      - ../mods/minimal.yaml
+      - ../mods/minimal_kafka.yaml.gotmpl
+      - ../mods/fast_deploy.yaml
+    {{ end }}
 
 ---
 

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -10,9 +10,14 @@ server_name: example.com
 maintainer_email: MAINTAINER_EMAIL@example.com
 # Number of Kafka pods that will be installed
 kafka_num_brokers: 3
+# Enable logging and monitoring
+enable_logging_monitoring: false
 # Enable TLS redirection and retrieval of Let's Encrypt certificates.
 # Can be disabled when TLS termination is handled upstream of the on-cluster Nginx reverse proxy.
 enable_tls: true
+
+# Minimal deployment for development (disables TLS, monitoring and logging, sets kafka and minio brokers to 1).
+dev_deployment: false
 
 
 # --------------------------------------------------------- 00-init.yaml ---------------------------------------------------------

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -465,7 +465,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
-  _chart_version: 0.3.4
+  _chart_version: 0.4.0
   _extra_timeout: 90
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.

--- a/helmfile.d/10-services.yaml
+++ b/helmfile.d/10-services.yaml
@@ -677,7 +677,7 @@ releases:
         value: {{ .Values.confluent_cloud.enabled }}
       - name: serviceMonitor.enabled
         value: {{ .Values.kube_prometheus_stack._install }}
-      {{- if .Values.confluent_cloud.enabled }}
+      {{ if .Values.confluent_cloud.enabled }}
       - name: schemaRegistry
         value: {{ .Values.confluent_cloud.cc.schemaRegistryUrl }}
       - name: bootstrapServers

--- a/mods/disable_monitoring_logging.yaml
+++ b/mods/disable_monitoring_logging.yaml
@@ -1,0 +1,63 @@
+# disables logging (in graylog) and monitoring (with prometheus)
+
+kube_prometheus_stack:
+  _install: false
+mongodb:
+  _install: false
+elasticsearch:
+  _install: false
+graylog:
+  _install: false
+fluent_bit:
+  _install: false
+
+cert_manager:
+  prometheus:
+    servicemonitor:
+      enabled: false
+postgresql:
+  metrics:
+    enabled: false
+  primary:
+    sidecars: []
+timescaledb:
+  metrics:
+    enabled: false
+  primary:
+    sidecars: []
+nginx_ingress:
+  controller:
+    metrics:
+      enabled: false
+      serviceMonitor:
+        enabled: false
+catalog_server:
+  prometheus:
+    jmx:
+      enabled: false
+cp_kafka:
+  prometheus:
+    jmx:
+      enabled: false
+cp_zookeeper:
+  prometheus:
+    jmx:
+      enabled: false
+cp_schema_registry:
+  prometheus:
+    jmx:
+      enabled: false
+redis:
+  metrics:
+    enabled: false
+minio:
+  metrics:
+    serviceMonitor:
+      enabled: false
+    prometheusRule:
+      enabled: false
+radar_upload_postgresql:
+  metrics:
+    enabled: false
+  primary:
+    sidecars: []

--- a/mods/fast_deploy.yaml
+++ b/mods/fast_deploy.yaml
@@ -1,0 +1,52 @@
+radar_home:
+  readinessProbe:
+    periodSeconds: 5
+app_config:
+  readinessProbe:
+    periodSeconds: 5
+app_config_frontend:
+  readinessProbe:
+    periodSeconds: 5
+management_portal:
+  readinessProbe:
+    periodSeconds: 5
+radar_appserver:
+  readinessProbe:
+    periodSeconds: 5
+data_dashboard_backend:
+  readinessProbe:
+    periodSeconds: 5
+radar_rest_sources_authorizer:
+  readinessProbe:
+    periodSeconds: 5
+radar_rest_sources_backend:
+  readinessProbe:
+    periodSeconds: 5
+radar_gateway:
+  readinessProbe:
+    periodSeconds: 5
+radar_integration:
+  readinessProbe:
+    periodSeconds: 5
+radar_upload_connect_frontend:
+  readinessProbe:
+    periodSeconds: 5
+radar_upload_connect_backend:
+  readinessProbe:
+    periodSeconds: 5
+radar_push_endpoint:
+  readinessProbe:
+    periodSeconds: 5
+kafka_manager:
+  readinessProbe:
+    periodSeconds: 5
+ccSchemaRegistryProxy:
+  readinessProbe:
+    periodSeconds: 5
+cert_manager:
+  webhook:
+    readinessProbe:
+      periodSeconds: 5
+minio:
+  readinessProbe:
+    periodSeconds: 5

--- a/mods/ksql-queries/_base_observations_stream.sql
+++ b/mods/ksql-queries/_base_observations_stream.sql
@@ -1,0 +1,20 @@
+SET 'auto.offset.reset' = 'earliest';
+
+-- Register the 'ksql_observations' topic (is created when not exists).
+CREATE STREAM observations (
+    PROJECT VARCHAR KEY,    -- 'KEY' means that this field is part of the kafka message key
+    SUBJECT VARCHAR KEY,
+    SOURCE VARCHAR KEY,
+    TOPIC_NAME VARCHAR,
+    CATEGORY VARCHAR,
+    VARIABLE VARCHAR,
+    OBSERVATION_TIME TIMESTAMP,
+    OBSERVATION_TIME_END TIMESTAMP,
+    TYPE VARCHAR,
+    VALUE_NUMERIC DOUBLE,
+    VALUE_TEXTUAL VARCHAR
+) WITH (
+    kafka_topic = 'ksql_observations',
+    partitions = 1,
+    format = 'avro'
+);

--- a/mods/ksql-queries/questionnaire_app_event_observations.sql
+++ b/mods/ksql-queries/questionnaire_app_event_observations.sql
@@ -1,0 +1,31 @@
+CREATE STREAM questionnaire_app_event (
+    projectId VARCHAR KEY,    -- 'KEY' means that this field is part of the kafka message key
+    userId VARCHAR KEY,
+    sourceId VARCHAR KEY,
+    questionnaireName VARCHAR,
+    eventType VARCHAR,
+    time DOUBLE,
+    metadata MAP<VARCHAR, VARCHAR>
+) WITH (
+    kafka_topic = 'questionnaire_app_event',
+    partitions = 1,
+    format = 'avro'
+);
+
+INSERT INTO observations
+WITH (QUERY_ID='questionnaire_app_event_observations')
+SELECT
+    q.projectId AS PROJECT,
+    q.userId AS SUBJECT,
+    q.sourceId AS SOURCE,
+    'questionnaire_app_event' as TOPIC_NAME,
+    q.questionnaireName as CATEGORY,
+    q.eventType as VARIABLE,
+    FROM_UNIXTIME(CAST(q.time * 1000 AS BIGINT)) as OBSERVATION_TIME,
+    CAST(NULL as TIMESTAMP) as OBSERVATION_TIME_END,
+    'STRING_JSON' as TYPE,
+    CAST(NULL as DOUBLE) as VALUE_NUMERIC,
+    TO_JSON_STRING(q.metadata) as VALUE_TEXTUAL
+FROM questionnaire_app_event q
+PARTITION BY q.projectId, q.userId, q.sourceId -- this sets the fields in the kafka message key
+EMIT CHANGES;

--- a/mods/ksql-queries/questionnaire_response_observations.sql
+++ b/mods/ksql-queries/questionnaire_response_observations.sql
@@ -1,0 +1,83 @@
+CREATE STREAM questionnaire_response (
+    projectId VARCHAR KEY, -- 'KEY' means that this field is part of the kafka message key
+    userId VARCHAR KEY,
+    sourceId VARCHAR KEY,
+    time DOUBLE,
+    timeCompleted DOUBLE,
+    timeNotification DOUBLE,
+    name VARCHAR,
+    version VARCHAR,
+    answers ARRAY<STRUCT<questionId VARCHAR, value STRUCT<int INT, string VARCHAR, double DOUBLE>, startTime DOUBLE, endTime DOUBLE>>
+) WITH (
+    kafka_topic = 'questionnaire_response',
+    partitions = 1,
+    format = 'avro'
+);
+
+CREATE STREAM questionnaire_response_exploded
+AS SELECT
+    EXPLODE(TRANSFORM(q.answers, a => a->questionId)) as VARIABLE,
+    FROM_UNIXTIME(CAST(q.time * 1000 AS BIGINT)) as OBSERVATION_TIME,
+    q.projectId,
+    q.userId,
+    q.sourceId,
+    'questionnaire_response' as TOPIC_NAME,
+    q.name as CATEGORY,
+    CAST(NULL as TIMESTAMP) as OBSERVATION_TIME_END,
+    -- WARNING!!! The cast from VARCHAR (string) to DOUBLE will throw an JAVA exception if the string is not a number.
+    -- This does not mean that the message will be lost. The value will be present in the VALUE_TEXTUAL_OPTIONAL field.
+    EXPLODE(TRANSFORM(q.answers, a => COALESCE(a->value->double, CAST(a->value->int as DOUBLE), CAST(a->value->string as DOUBLE)))) as VALUE_NUMERIC,
+    EXPLODE(TRANSFORM(q.answers, a => CASE
+        WHEN a->value->int IS NOT NULL THEN 'INTEGER'
+        WHEN a->value->double IS NOT NULL THEN 'DOUBLE'
+        ELSE NULL
+    END)) as TYPE,
+    -- Note: When cast to double works for the string value, the VALUE_TEXTUAL_OPTIONAL will also be set.
+    EXPLODE(TRANSFORM(q.answers, a => a->value->string)) as VALUE_TEXTUAL_OPTIONAL
+FROM questionnaire_response q
+EMIT CHANGES;
+
+INSERT INTO observations
+WITH (QUERY_ID='questionnaire_response_observations')
+SELECT
+   q.projectId as PROJECT,
+   q.sourceId as SOURCE,
+   q.userId as SUBJECT,
+   TOPIC_NAME, CATEGORY, VARIABLE, OBSERVATION_TIME, OBSERVATION_TIME_END,
+   CASE
+       WHEN TYPE IS NULL AND VALUE_NUMERIC IS NOT NULL THEN 'DOUBLE' -- must have been derived from a string cast
+       WHEN TYPE IS NULL AND VALUE_NUMERIC IS NULL THEN 'STRING'
+       ELSE TYPE                                                     -- keep the original type when TYPE is not NULL
+   END as TYPE,
+   VALUE_NUMERIC,
+    CASE
+        WHEN VALUE_NUMERIC IS NOT NULL THEN NULL                     -- When cast to double has worked for the string value, set VALUE_TEXTUAL to NULL.
+        ELSE VALUE_TEXTUAL_OPTIONAL
+    END as VALUE_TEXTUAL
+FROM questionnaire_response_exploded q
+PARTITION BY q.projectId, q.userId, q.sourceId -- this sets the fields in the kafka message key
+EMIT CHANGES;
+
+-- TODO: exploding the 'select:' questions is not yet fully designed.
+-- I keep the code here for future reference.
+-- Multi-select questionnaire questions are stored as a single 'value' string with the
+-- names of the selected options separated by comma's. Multiselect questions are prefixed
+-- by 'select:' in the questionId.
+-- When 'questionId' is like 'select:%' create a new stream with the select options.
+-- The options in the value field split commas and added as separate VARIABLE records.
+-- The VALUE_NUMERIC is set to 1 and VALUE_TEXTUAL is set to NULL.
+-- INSERT INTO observations
+-- SELECT
+--     EXPLODE(SPLIT(VALUE_TEXTUAL, ',')) as VARIABLE,
+--     PROJECT, SOURCE, SUBJECT, TOPIC_NAME, CATEGORY, OBSERVATION_TIME, OBSERVATION_TIME_END,
+--     'INTEGER' as TYPE,
+--     CAST(1 as DOUBLE) VALUE_NUMERIC,
+--     CAST(NULL as VARCHAR) as VALUE_TEXTUAL
+-- FROM questionnaire_response_observations
+-- WHERE
+--  VARIABLE IS NOT NULL
+--  AND VARIABLE LIKE 'select:%'
+--  AND VALUE_TEXTUAL IS NOT NULL
+--  AND VALUE_TEXTUAL != ''
+-- PARTITION BY SUBJECT, PROJECT, SOURCE
+-- EMIT CHANGES;

--- a/mods/localdev.yaml
+++ b/mods/localdev.yaml
@@ -1,0 +1,52 @@
+# must be localhost for session cookies to work in 'secure' mode
+server_name: localhost
+
+base_timeout: 360
+atomicInstall: false
+
+radar_home:
+  s3:
+    url: http://s3.localhost/login
+  dashboard:
+    url: http://grafana.localhost
+  logging:
+    enabled: true # either logging or monitoring must be enabled or radar-home crashes
+    url: http://graylog.localhost
+  monitoring:
+    enabled: true # either logging or monitoring must be enabled or radar-home crashes
+    url: http://grafana.localhost/login
+kratos:
+  config:
+    serve:
+      public:
+        base_url: http://localhost/kratos/
+        cors:
+          allowed_origins:
+            - http://localhost/kratos-ui/
+      admin:
+        base_url: http://localhost/admin/kratos/
+    selfservice:
+      default_browser_return_url: http://localhost/managementportal
+      allowed_return_urls:
+        - "http://localhost/"
+      flows:
+        error:
+          ui_url: http://localhost/kratos-ui/
+        recovery:
+          ui_url: http://localhost/kratos-ui/recovery
+        registration:
+          ui_url: http://localhost/kratos-ui/registration
+        login:
+          ui_url: http://localhost/kratos-ui/login
+        logout:
+          after:
+            default_browser_return_url: http://localhost/kratos-ui/login
+        verification:
+          ui_url: http://localhost/kratos-ui/verification
+          after:
+            default_browser_return_url: http://localhost/kratos-ui
+        settings:
+          ui_url: http://localhost/kratos-ui/settings
+kratos_ui:
+  kratosPublicUrl: http://localhost/kratos
+  kratosBrowserUrl: http://localhost/kratos

--- a/mods/minimal.yaml
+++ b/mods/minimal.yaml
@@ -1,0 +1,50 @@
+radar_s3_connector:
+  kafkaHeapOpts: "-Xms128m -Xmx256m"
+radar_output:
+  javaOpts: "-Xms128m -Xmx128m"
+cp_kafka:
+  heapOptions: "-Xms128M -Xmx512M"
+  persistence:
+    size: 1Gi
+cp_zookeeper:
+  heapOptions: "-Xms128M -Xmx128M"
+cp_schema_registry:
+  heapOptions: "-Xms128M -Xmx128M"
+minio:
+  # Turn off distributed mode for minio
+  mode: standalone
+  persistence:
+    size: 1Gi
+elasticsearch:
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "500Mi"
+postgresql:
+  primary:
+    resources:
+      requests:
+        cpu: 50m
+    persistence:
+      size: 1Gi
+radar_appserver_postgresql:
+  primary:
+    resources:
+      requests:
+        cpu: 50m
+    persistence:
+      size: 1Gi
+timescaledb:
+  primary:
+    resources:
+      requests:
+        cpu: 50m
+    persistence:
+      size: 1Gi
+radar_upload_postgresql:
+  primary:
+    resources:
+      requests:
+        cpu: 50m
+    persistence:
+      size: 1Gi

--- a/mods/minimal_kafka.yaml.gotmpl
+++ b/mods/minimal_kafka.yaml.gotmpl
@@ -1,0 +1,21 @@
+kafka_num_brokers: 1
+catalog_server:
+  kafka_num_replication: 1
+  kafka_num_partitions: 1
+cp_kafka:
+  configurationOverrides:
+    "offsets.topic.replication.factor": 1
+    "default.replication.factor": 1
+cp_zookeeper:
+  servers: 1
+ksql_server:
+  ksql:
+    # Needed to reduce the number of partitions (hard-coded in these SQL files) to 1.
+    queries: |
+      {{- readFile "ksql-queries/_base_observations_stream.sql"             | nindent 8 }}
+      {{- readFile "ksql-queries/questionnaire_response_observations.sql"   | nindent 8 }}
+      {{- readFile "ksql-queries/questionnaire_app_event_observations.sql"  | nindent 8 }}
+  configurationOverrides:
+    "ksql.internal.topic.replicas": 1
+radar_jdbc_connector_data_dashboard_backend:
+  kafka: PLAINTEXT://cp-kafka:9092


### PR DESCRIPTION
Note! This PR targets the version/various-charts branch. The target should be updated to dev after merge of this branch.

This PR will implement various changes to helmfile that aim to facilitate local development and testing of RADAR-base. These changes include:

- Local host name set to _localhost_
- Disable Prometheus monitoring
- Disable Grafana logging
- Run Kafka with single broker/zookeeper
- Run Minio with single broker (standalone mode)
- Run many services at minimal RAM usage and disk footprint
- Increase the rate for readyState polling so that pods initiate faster (untested)

# Discussion
The KSQL-server transformation scripts have hard coded number of partitions in their transformer logic. This forced me to copy these 'queries' files and reduce the partition number to 1. This also is problematic when changing `kafka_num_brokers`?
