### PR TITLE
[radar-appserver] Up chart version to 0.5.0

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -253,7 +253,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.2.2
+  _chart_version: 0.5.0
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer


### PR DESCRIPTION
# Description of the change
This PR will up the appserver appversion. This version can make use of SMTP connection credentials to the Appserver application to send notifications via email alongside push notifications.
