### PR TITLE
bugfix/generate-random-minio-credentials

### DIFF
--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -152,8 +152,8 @@ radar_integration:
 # --------------------------------------------------------- 20-s3-connector.yaml ---------------------------------------------------------
 # The access keys and secret keys of object storage services should match.
 # If AWS S3 is used as a storage medium instead of minio, then fill in those.
-s3_access_key: change_me
-s3_secret_key: change_me
+s3_access_key: secret
+s3_secret_key: secret
 
 # --------------------------------------------------------- 20-upload.yaml ---------------------------------------------------------
 radar_upload_postgres_password: secret


### PR DESCRIPTION

# Problem
At present, the admin username and passwords are not updated by the _generate-passwords_ script and remain `change_me/change_me`.

# Solution
This PR will enable the _generate-passwords_ script to create Minio passwords.