### PR TITLE
Create minimal production.yaml

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -10,8 +10,8 @@ if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
 fi
 
 copy_template_if_absent environments.yaml environments.yaml.tmpl
-copy_template_if_absent etc/production.yaml etc/base.yaml
 copy_template_if_absent etc/production.yaml.gotmpl etc/base.yaml.gotmpl
+create_production_yaml
 
 DNAME="$DNAME" bin/keystore-init
 bin/generate-secrets

--- a/bin/util.sh
+++ b/bin/util.sh
@@ -49,10 +49,8 @@ create_production_yaml() {
   copy_template_if_absent etc/production.yaml etc/base.yaml
   tempfile=$(mktemp)
   mv etc/production.yaml $tempfile
-  # only keep the 'atomicInstall', etc. fields
-  cat $tempfile | grep -vE "^\s*#" | grep -E "atomicInstall|kubeContext|server_name|maintainer_email" > etc/production.yaml
-  # only keep the '_install: true/false' fields
-  cat $tempfile | grep -vE "^\s*#" | grep -B 1 --no-group-separator "_install:" >> etc/production.yaml
+  # remove all '_chart_version' fields
+  cat $tempfile | grep -v _chart_version > etc/production.yaml
 }
 
 # Copies the template (defined by the given config file with suffix

--- a/bin/util.sh
+++ b/bin/util.sh
@@ -45,6 +45,16 @@ copy_template_if_absent() {
   fi
 }
 
+create_production_yaml() {
+  copy_template_if_absent etc/production.yaml etc/base.yaml
+  tempfile=$(mktemp)
+  mv etc/production.yaml $tempfile
+  # only keep the 'atomicInstall', etc. fields
+  cat $tempfile | grep -vE "^\s*#" | grep -E "atomicInstall|kubeContext|server_name|maintainer_email" > etc/production.yaml
+  # only keep the '_install: true/false' fields
+  cat $tempfile | grep -vE "^\s*#" | grep -B 1 --no-group-separator "_install:" >> etc/production.yaml
+}
+
 # Copies the template (defined by the given config file with suffix
 # ".template") to intended configuration file.
 copy_template() {


### PR DESCRIPTION
# Problem
Then initializing a new project the _production.yaml_ file is created that will hold the deployment-specific configuration. At present, the entire _base.yaml_ contents are reflected in _production.yaml_. This makes it difficult to spot the deployment-specific configuration.

# Solution
This PR will filter _base.yaml_ to only contain the `_install:` fields and the  deployment specific fields `atomicInstall`, `kubeContext`, `server_name` and `maintainer_email`. It will look like this:

```
atomicInstall: true
kubeContext: default
server_name: example.com
maintainer_email: MAINTAINER_EMAIL@example.com
mongodb:
  _install: true
elasticsearch:
  _install: true
graylog:
  _install: true
fluent_bit:
  _install: true
cert_manager:
  _install: true
kube_prometheus_stack:
  _install: true
nginx_ingress:
  _install: true
kafka_manager:
  _install: false
cert_manager_letsencrypt:
  _install: true
cp_zookeeper:
  _install: true
cp_kafka:
  _install: true
cp_schema_registry:
  _install: true
catalog_server:
  _install: true
radar_home:
  _install: true
postgresql:
  _install: true
management_portal:
  _install: true
kratos:
  _install: true
kratos_ui:
  _install: true
app_config:
  _install: true
app_config_frontend:
  _install: true
radar_appserver_postgresql:
  _install: false
radar_appserver:
  _install: false
radar_fitbit_connector:
  _install: false
radar_oura_connector:
  _install: false
radar_rest_sources_authorizer:
  _install: false
radar_rest_sources_backend:
  _install: false
timescaledb:
  _install: true
radar_grafana:
  _install: false
data_dashboard_backend:
  _install: false
radar_jdbc_connector_grafana:
  _install: false
radar_jdbc_connector_data_dashboard_backend:
  _install: false
radar_jdbc_connector_realtime_dashboard:
  _install: false
ksql_server:
  _install: false
radar_gateway:
  _install: true
radar_backend_monitor:
  _install: false
radar_backend_stream:
  _install: false
radar_integration:
  _install: false
redis:
  _install: true
minio:
  _install: true
radar_s3_connector:
  _install: true
s3_proxy:
  _install: false
radar_output:
  _install: true
radar_upload_postgresql:
  _install: true
radar_upload_connect_backend:
  _install: true
radar_upload_connect_frontend:
  _install: true
radar_upload_source_connector:
  _install: true
ccSchemaRegistryProxy:
  _install: false
radar_push_endpoint:
  _install: false
velero:
  _install: false
```