### PR TITLE
Up chart version of radar-ooutput-restructure to 1.0.0

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -482,7 +482,7 @@ s3_proxy:
 
 radar_output:
   _install: true
-  _chart_version: 0.4.1
+  _chart_version: 1.0.0
   _extra_timeout: 0
   replicaCount: 1
   source:


### PR DESCRIPTION
See title. Interface change of the chart does not result in changed the the deployment code.