### PR TITLE
Removed kafka-manager

### DIFF
--- a/.github/ci_config/ci-config.yaml
+++ b/.github/ci_config/ci-config.yaml
@@ -7,9 +7,6 @@ elasticsearch:
       cpu: "100m"
       memory: "500Mi"
 
-kafka_manager:
-  _install: false
-
 confluent_cloud:
   enabled: false
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Before running the upgrade, compare `etc/base.yaml` and `etc/base.yaml.gotmpl` w
 To upgrade the initial services, run
 
 ```shell
-kubectl delete -n monitoring deployments kube-prometheus-stack-kube-state-metrics kafka-manager
+kubectl delete -n monitoring deployments kube-prometheus-stack-kube-state-metrics
 helm -n graylog uninstall mongodb
 kubectl delete -n graylog pvc datadir-mongodb-0 datadir-mongodb-1
 ```

--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -40,10 +40,6 @@ kube_prometheus_stack:
     # Or automatically via `bin/generate-secrets` script
     nginx_auth: thehyve:$apr1$5HSenBgF$9VKLQchT85Nrt5I3Vd6H3. # username: thehyve, password: password
 
-kafka_manager:
-  basicAuth:
-    password: secret
-
 # --------------------------------------------------------- 10-base.yaml ---------------------------------------------------------
 confluent_cloud:
   cc:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -108,12 +108,6 @@ nginx_ingress:
       serviceMonitor:
         enabled: true
 
-# Kafka manager is outdated but can still be used. Otherwise, use Kafka command-line tools.
-kafka_manager:
-  _install: false
-  _chart_version: 2.2.0
-  _extra_timeout: 0
-
 # --------------------------------------------------------- 10-base.yaml ---------------------------------------------------------
 # Use letsencrypt to retrieve SSL certificates.
 cert_manager_letsencrypt:

--- a/helmfile.d/10-services.yaml
+++ b/helmfile.d/10-services.yaml
@@ -84,24 +84,6 @@ releases:
       - name: controller.metrics.serviceMonitor.enabled
         value: {{ .Values.kube_prometheus_stack._install }}
 
-  - name: kafka-manager
-    chart: radar/kafka-manager
-    version: {{ .Values.kafka_manager._chart_version }}
-    installed: {{ .Values.kafka_manager._install }}
-    timeout: {{ add .Values.base_timeout .Values.kafka_manager._extra_timeout }}
-    <<: *logFailedRelease
-    values:
-      - {{ .Values.kafka_manager | toYaml | indent 8 | trim }}
-    set:
-      - name: ingress.hosts
-        values:
-          - {{ .Values.server_name }}
-      - name: ingress.tls.secretName
-        value: radar-base-tls
-      - name: ingress.tls.hosts
-        values:
-          - {{ .Values.server_name }}
-
   - name: cert-manager-letsencrypt
     namespace: cert-manager
     chart: radar/cert-manager-letsencrypt

--- a/mods/disable_tls.yaml
+++ b/mods/disable_tls.yaml
@@ -32,7 +32,5 @@ radar_upload_connect_backend:
   disable_tls: true
 radar_push_endpoint:
   disable_tls: true
-kafka_manager:
-  disable_tls: true
 ccSchemaRegistryProxy:
   disable_tls: true

--- a/mods/fast_deploy.yaml
+++ b/mods/fast_deploy.yaml
@@ -37,9 +37,6 @@ radar_upload_connect_backend:
 radar_push_endpoint:
   readinessProbe:
     periodSeconds: 5
-kafka_manager:
-  readinessProbe:
-    periodSeconds: 5
 ccSchemaRegistryProxy:
   readinessProbe:
     periodSeconds: 5


### PR DESCRIPTION
Kafka manager has probably never been used in RADAR-Kubernetes and is quite outdated. This PR removes it. Also closes #125