### PR TITLE
Fix missing serverName value for app-config

### DIFF
--- a/helmfile.d/10-services.yaml
+++ b/helmfile.d/10-services.yaml
@@ -281,6 +281,8 @@ releases:
     set:
       - name: ingress.hosts
         values: [{{ .Values.server_name }}]
+      - name: serverName
+        value: {{ .Values.server_name }}
 
   - name: kratos
     chart: radar/kratos


### PR DESCRIPTION
This PR will fix the missing serverName value for app-config. This caused the return URL to contain `localhost`.