### PR TITLE
Fix default password for minio.

### DIFF
--- a/bin/generate-secrets
+++ b/bin/generate-secrets
@@ -64,8 +64,8 @@ nginx_auth_password=$(generate_secret)
 secret="thehyve:$(echo $nginx_auth_password | openssl passwd -apr1 -stdin)" insert_secret ".kube_prometheus_stack.nginx_auth"
 comment="username: thehyve, password: $nginx_auth_password" yq -i ".kube_prometheus_stack.nginx_auth line_comment |= strenv(comment)" etc/secrets.yaml
 
-# Generate secrets for all remaining fields with value 'secret'.
-replacements=$(yq e '.. | select(. == "secret") | [(path | "."+join("."))] | join(" ")' etc/secrets.yaml);
+# Generate secrets for all remaining fields with value 'secret' or 'secret-secret' (if the component has a min length requirement).
+replacements=$(yq e '.. | select(. == "secret" or "secret-secret") | [(path | "."+join("."))] | join(" ")' etc/secrets.yaml);
 for key in $replacements; do
   insert_secret $key
 done

--- a/etc/base-secrets.yaml
+++ b/etc/base-secrets.yaml
@@ -147,9 +147,10 @@ radar_integration:
 
 # --------------------------------------------------------- 20-s3-connector.yaml ---------------------------------------------------------
 # The access keys and secret keys of object storage services should match.
-# If AWS S3 is used as a storage medium instead of minio, then fill in those.
-s3_access_key: secret
-s3_secret_key: secret
+# If AWS S3 is used as a storage medium instead of minio, then enter the AWS-provided secrets here.
+# For minio the secrets must consist of at least 8 characters.
+s3_access_key: secret-secret
+s3_secret_key: secret-secret
 
 # --------------------------------------------------------- 20-upload.yaml ---------------------------------------------------------
 radar_upload_postgres_password: secret


### PR DESCRIPTION
MinIO won't start if the password length is less than 9 characters.

In the development setup there was a default password for MinIO, which does not meet the requirements (at least 8 characters). With that setup Minio hangs on "Adding local minio host to 'mc' configuration. " and won't start. 

Note added by @pvannierop 
Being able to use unmodified passwords is only relevant for development deployments that run wit non-randomized passwords. Hence, this change does not affect production envrionments.
