### PR TITLE
Release 1.2.1

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -46,6 +46,7 @@ jobs:
           sed -i "/secrets.yaml/a $helmfile_mods" environments.yaml
           sed -i '/_install: /s/false/true/' etc/production.yaml
           sed -i '/enable_logging_monitoring: /s/false/true/' etc/production.yaml
+          echo "github_installation_test: true" >> etc/production.yaml
 
       - name: Run helmfile template
         env:

--- a/environments.yaml.tmpl
+++ b/environments.yaml.tmpl
@@ -19,6 +19,14 @@ environments:
       - ../mods/minimal_kafka.yaml.gotmpl
       - ../mods/fast_deploy.yaml
     {{ end }}
+    {{ if .Values.github_installation_test }}
+      - ../mods/disable_monitoring_logging.yaml
+      - ../mods/localdev.yaml
+      - ../mods/minimal.yaml
+      - ../mods/minimal_kafka.yaml.gotmpl
+      - ../mods/fast_deploy.yaml
+    {{ end }}
+
 
 ---
 

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -65,7 +65,7 @@ cert_manager:
 # kubectl --context <my-context> apply --force-conflicts --server-side -f etc/kube-prometheus-stack/files/crds.yaml
 kube_prometheus_stack:
   _install: true
-  _chart_version: 0.4.4
+  _chart_version: 0.4.6
   _extra_timeout: 0
   kube-prometheus-stack:
     prometheus:
@@ -112,7 +112,7 @@ nginx_ingress:
 # Use letsencrypt to retrieve SSL certificates.
 cert_manager_letsencrypt:
   _install: true
-  _chart_version: 0.1.3
+  _chart_version: 0.2.0
   _extra_timeout: 0
 
 # Use confluent cloud instead of a local Kafka cluster.
@@ -122,13 +122,13 @@ confluent_cloud:
 
 cp_zookeeper:
   _install: true
-  _chart_version: 0.3.4
+  _chart_version: 0.3.5
   _extra_timeout: 510
   servers: 3
 
 cp_kafka:
   _install: true
-  _chart_version: 0.3.5
+  _chart_version: 0.3.6
   _extra_timeout: 510
   customEnv:
     # Set this to 1.1 when upgrading from Kafka 5.x
@@ -142,20 +142,20 @@ cp_kafka:
 
 cp_schema_registry:
   _install: true
-  _chart_version: 0.3.2
+  _chart_version: 0.3.3
   _extra_timeout: 90
   replicaCount: 1
 
 catalog_server:
   _install: true
-  _chart_version: 0.6.3
+  _chart_version: 0.7.1
   _extra_timeout: 90
   replicaCount: 1
   schema_registry: http://cp-schema-registry:8081
 
 radar_home:
   _install: true
-  _chart_version: 0.3.5
+  _chart_version: 0.4.2
   _extra_timeout: 0
 
 # --------------------------------------------------------- 10-managementportal.yaml ---------------------------------------------------------
@@ -163,7 +163,7 @@ radar_home:
 # This Postgresql is used for Management Portal and App config, postgres password should be same in them
 postgresql:
   _install: true
-  _chart_version: 0.1.0
+  _chart_version: 0.1.2
   _extra_timeout: 0
   postgresql:
     replication:
@@ -180,7 +180,7 @@ postgresql:
 
 management_portal:
   _install: true
-  _chart_version: 1.3.1
+  _chart_version: 1.4.2
   _extra_timeout: 210
   replicaCount: 1  # should be 1
   postgres:
@@ -220,7 +220,7 @@ kratos_ui:
 
 app_config:
   _install: true
-  _chart_version: 1.3.4
+  _chart_version: 1.4.1
   _extra_timeout: 0
   replicaCount: 1
   jdbc:
@@ -228,7 +228,7 @@ app_config:
 
 app_config_frontend:
   _install: true
-  _chart_version: 2.1.1
+  _chart_version: 2.2.1
   _extra_timeout: 0
   replicaCount: 1
 
@@ -236,7 +236,7 @@ app_config_frontend:
 # The charts in 20-appserver.yaml only need to be installed if you have a custom aRMT app.
 radar_appserver_postgresql:
   _install: false
-  _chart_version: 0.1.0
+  _chart_version: 0.1.2
   _extra_timeout: 0
   postgresql:
     auth:
@@ -252,7 +252,7 @@ radar_appserver_postgresql:
 
 radar_appserver:
   _install: false
-  _chart_version: 0.7.2
+  _chart_version: 0.8.2
   _extra_timeout: 0
   replicaCount: 1
   managementportal_resource_name: res_AppServer
@@ -271,27 +271,27 @@ radar_appserver:
 # The charts in 20-fitbit.yaml only need to be installed if you will use a Fitbit, Garmin, or Oura API integration.
 radar_fitbit_connector:
   _install: false
-  _chart_version: 0.4.0
+  _chart_version: 0.7.2
   _extra_timeout: 0
   replicaCount: 1
   oauthClientId: radar_fitbit_connector
 
 radar_oura_connector:
   _install: false
-  _chart_version: 0.0.5
+  _chart_version: 0.2.2
   _extra_timeout: 0
   replicaCount: 1
   oauthClientId: radar_oura_connector
 
 radar_rest_sources_authorizer:
   _install: false
-  _chart_version: 2.1.3
+  _chart_version: 2.2.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_rest_sources_backend:
   _install: false
-  _chart_version: 1.2.3
+  _chart_version: 1.3.1
   _extra_timeout: 0
   replicaCount: 1
   postgres:
@@ -318,7 +318,7 @@ realtime_dashboard_db_username: postgres
 # Install when data_dashboard_backend._install is 'true'
 data_dashboard_timescaledb:
   _install: false
-  _chart_version: 0.1.0
+  _chart_version: 0.1.1
   _extra_timeout: 210
   replicaCount: 1
   postgresql:
@@ -336,7 +336,7 @@ data_dashboard_timescaledb:
 # Install when radar_grafana._install is 'true'
 grafana_metrics_timescaledb:
   _install: false
-  _chart_version: 0.1.0
+  _chart_version: 0.1.1
   _extra_timeout: 210
   replicaCount: 1
   postgresql:
@@ -354,7 +354,7 @@ grafana_metrics_timescaledb:
 # Install when using realtime analysis
 realtime_dashboard_timescaledb:
   _install: false
-  _chart_version: 0.1.0
+  _chart_version: 0.1.1
   _extra_timeout: 210
   replicaCount: 1
   postgresql:
@@ -387,14 +387,14 @@ radar_grafana:
 #- ksql_server._install to true
 data_dashboard_backend:
   _install: false
-  _chart_version: 0.3.7
+  _chart_version: 0.4.2
   _extra_timeout: 0
   replicaCount: 1
 
 # Install when radar_grafana._install is 'true'
 radar_jdbc_connector_grafana:
   _install: false
-  _chart_version: 0.5.5
+  _chart_version: 0.6.2
   _extra_timeout: 0
   replicaCount: 1
   sink:
@@ -404,14 +404,14 @@ radar_jdbc_connector_grafana:
 # Install when data_dashboard_backend._install is 'true'.
 radar_jdbc_connector_data_dashboard_backend:
   _install: false
-  _chart_version: 0.5.5
+  _chart_version: 0.6.2
   _extra_timeout: 0
   replicaCount: 1
 
 # Install when using realtime analysis
 radar_jdbc_connector_realtime_dashboard:
   _install: false
-  _chart_version: 0.5.5
+  _chart_version: 0.6.2
   _extra_timeout: 0
   replicaCount: 1
 
@@ -421,7 +421,7 @@ radar_jdbc_connector_realtime_dashboard:
 #- using realtime analysis
 ksql_server:
   _install: false
-  _chart_version: 0.3.3
+  _chart_version: 0.3.4
   _extra_timeout: 0
   # -- Uncomment when using real-time analysis
   # ksql:
@@ -432,7 +432,7 @@ ksql_server:
 
 radar_gateway:
   _install: true
-  _chart_version: 1.2.9
+  _chart_version: 1.4.4
   _extra_timeout: 0
   replicaCount: 1
 
@@ -440,7 +440,7 @@ radar_gateway:
 
 radar_backend_monitor:
   _install: false
-  _chart_version: 0.3.1
+  _chart_version: 0.4.0
   _extra_timeout: 0
   replicaCount: 1
   smtp:
@@ -452,7 +452,7 @@ radar_backend_monitor:
 
 radar_backend_stream:
   _install: false
-  _chart_version: 0.3.1
+  _chart_version: 0.4.0
   _extra_timeout: 0
   replicaCount: 1
 
@@ -460,7 +460,7 @@ radar_backend_stream:
 
 radar_integration:
   _install: false
-  _chart_version: 0.7.3
+  _chart_version: 0.8.1
   _extra_timeout: 0
   replicaCount: 1
   oauth_client_id: radar_redcap_integrator
@@ -500,7 +500,7 @@ minio:
 radar_s3_connector:
   # set to true if radar-s3-connector should be installed
   _install: true
-  _chart_version: 0.4.1
+  _chart_version: 0.5.2
   _extra_timeout: 90
   replicaCount: 1
   # The bucket name where intermediate data for cold storage should be written to.
@@ -509,7 +509,7 @@ radar_s3_connector:
 
 s3_proxy:
   _install: false
-  _chart_version: 0.4.2
+  _chart_version: 0.5.1
   _extra_timeout: 0
   replicaCount: 1
   target:
@@ -517,7 +517,7 @@ s3_proxy:
 
 radar_output:
   _install: true
-  _chart_version: 1.0.1
+  _chart_version: 1.2.1
   _extra_timeout: 0
   replicaCount: 1
   source:
@@ -536,7 +536,7 @@ radar_output:
 
 radar_upload_postgresql:
   _install: true
-  _chart_version: 0.1.0
+  _chart_version: 0.1.2
   _extra_timeout: 0
   postgresql:
     auth:
@@ -552,19 +552,19 @@ radar_upload_postgresql:
 
 radar_upload_connect_backend:
   _install: false
-  _chart_version: 0.5.3
+  _chart_version: 0.6.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_connect_frontend:
   _install: false
-  _chart_version: 0.5.1
+  _chart_version: 0.6.1
   _extra_timeout: 0
   replicaCount: 1
 
 radar_upload_source_connector:
   _install: false
-  _chart_version: 0.3.4
+  _chart_version: 0.4.2
   _extra_timeout: 60
   replicaCount: 1
   s3Endpoint: http://minio:9000/
@@ -573,7 +573,7 @@ radar_upload_source_connector:
 
 ccSchemaRegistryProxy:
   _install: false
-  _chart_version: 0.3.3
+  _chart_version: 0.4.1
   _extra_timeout: 0
   externalName: schema-registry-domain
 
@@ -581,7 +581,7 @@ ccSchemaRegistryProxy:
 
 radar_push_endpoint:
   _install: false
-  _chart_version: 0.3.6
+  _chart_version: 0.4.2
   _extra_timeout: 180
   replicaCount: 1
   adminProperties: {}
@@ -592,7 +592,7 @@ radar_push_endpoint:
 
 velero:
   _install: false
-  _chart_version: 0.3.2
+  _chart_version: 0.4.1
   _extra_timeout: 0
   objectStorageBackupReplicaCount: 1
   backup:

--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -98,7 +98,7 @@ kube_prometheus_stack:
 # Always needed
 nginx_ingress:
   _install: true
-  _chart_version: 4.10.1
+  _chart_version: 4.12.1
   _extra_timeout: 0
   controller:
     replicaCount: 1

--- a/etc/nginx-ingress/values.yaml
+++ b/etc/nginx-ingress/values.yaml
@@ -8,6 +8,7 @@ controller:
   config:
     ssl-redirect: "true"
     server-tokens: "false"
+    annotations-risk-level: "Critical"
   addHeaders:
     X-Frame-Options: Deny
     X-Xss-Protection: 1; mode=block


### PR DESCRIPTION
As part of the March 2025 security updates we prepare for the 1.2.1 release of RADAR-Kubernetes. This release does not include any functional changes, but merely changes that aim to fix detected software vulnerabilities. Importantly, this release fixes [Ingress-nginx CVE-2025-1974](https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/).