### PR TITLE
ci: include recent k8s releases in test matrix

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -1,12 +1,22 @@
 [
   {
-    "KUBECTL_VERSION": "v1.31.0",
-    "K3S_VERSION": "v1.31.2+k3s1",
+    "KUBECTL_VERSION": "v1.33.0",
+    "K3S_VERSION": "v1.33.2+k3s1",
     "runOnBranch": "always"
   },
   {
+    "KUBECTL_VERSION": "v1.32.0",
+    "K3S_VERSION": "v1.32.6+k3s1",
+    "runOnBranch": "main"
+  },
+  {
+    "KUBECTL_VERSION": "v1.31.0",
+    "K3S_VERSION": "v1.31.10+k3s1",
+    "runOnBranch": "main"
+  },
+  {
     "KUBECTL_VERSION": "v1.30.0",
-    "K3S_VERSION": "v1.30.6+k3s1",
+    "K3S_VERSION": "v1.30.14+k3s1",
     "runOnBranch": "main"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ While this documentation will provide guidance for installing and configuring RA
 Currently RADAR-Kubernetes is tested and supported on following component versions:
 | Component | Version |
 | ---- | ------- |
-| Kubernetes | v1.30 and v1.31 |
-| K3s | v1.30.6+k3s1 and v1.31.2+k3s1 |
-| Kubectl | v1.30 and v1.31 |
+| Kubernetes | v1.30, v1.31, v1.32 and v1.33 |
+| K3s | v1.30.6+k3s1, v1.31.10+k3s1, v1.32.6+k3s1 and v1.33.2+k3s1 |
+| Kubectl | v1.30, v1.31, v1.32 and v1.33 |
 | Helm | v3.16.3 |
 | Helm diff | 3.9.12 |
 | Helmfile | v0.169.1 |


### PR DESCRIPTION
This PR will expand the set of k8s versions that is tested after merge to main branch to include the more recent versions 1.32 and 1.33.