### PR TITLE
updated redis sysctl image to bitnami/os-shell

### DIFF
--- a/etc/redis/values.yaml
+++ b/etc/redis/values.yaml
@@ -52,6 +52,11 @@ sysctl:
   enabled: true
   ## @param sysctl.command override default init-sysctl container command (useful when using custom images)
   ##
+  sysctl:
+    image:
+        registry: docker.io
+        repository: bitnami/os-shell
+        tag: 12-debian-12-r49
   command:
     - /bin/sh
     - -c
@@ -62,4 +67,3 @@ sysctl:
   ## @param sysctl.mountHostSys Mount the host `/sys` folder to `/host-sys`
   ##
   mountHostSys: true
- 

--- a/etc/redis/values.yaml
+++ b/etc/redis/values.yaml
@@ -67,3 +67,9 @@ sysctl:
   ## @param sysctl.mountHostSys Mount the host `/sys` folder to `/host-sys`
   ##
   mountHostSys: true
+
+volumePermissions:
+  image:
+        registry: docker.io
+        repository: bitnami/os-shell
+        tag: 12-debian-12-r49


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The [docker.io/bitnami/bitnami-shell](http://docker.io/bitnami/bitnami-shell) is archived now, resulting in redis crashing. Updated the default image to [docker.io/bitnami/os-shell.](https://hub.docker.com/r/bitnami/os-shell)

**Benefits**


<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- Make sure application versions in compatiblity section of README is same as the versions tested in CI
