### PR TITLE
fix: use bitnamilegacy image repository

### DIFF
--- a/etc/base.yaml
+++ b/etc/base.yaml
@@ -167,7 +167,7 @@ radar_home:
 # DEPRECATED: Use cloudnative_postgresql instead
 postgresql:
   _install: false
-  _chart_version: 0.1.2
+  _chart_version: 0.1.4
   _extra_timeout: 0
   postgresql:
     replication:

--- a/etc/minio/values.yaml
+++ b/etc/minio/values.yaml
@@ -1,3 +1,5 @@
+image:
+  repository: bitnamilegacy/minio
 ## @param mode MinIO&reg; server mode (`standalone` or `distributed`)
 ## ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
 ##

--- a/etc/mongodb/values.yaml
+++ b/etc/mongodb/values.yaml
@@ -1,3 +1,18 @@
+image:
+  repository: bitnamilegacy/mongodb
+tls:
+  image:
+    repository: bitnamilegacy/nginx
+externalAccess:
+  image:
+    repository: bitnamilegacy/kubectl
+  dnsCheck:
+    image:
+      repository: bitnamilegacy/os-shell
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell
+
 ## MongoDB(&reg;) Authentication parameters
 ##
 auth:
@@ -15,9 +30,9 @@ auth:
   ## @param auth.passwords List of passwords for the custom users set at `auth.usernames`
   ## @param auth.databases List of custom databases to be created during the initialization
   ##
-  usernames: [graylog]
-  passwords: []
-  databases: [graylog]
+  usernames: [ graylog ]
+  passwords: [ ]
+  databases: [ graylog ]
 ## MongoDB(&reg;) containers' resource requests and limits.
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -49,3 +64,5 @@ metrics:
   ## @param metrics.enabled Enable using a sidecar Prometheus exporter
   ##
   enabled: true
+  image:
+    repository: bitnamilegacy/mongodb-exporter

--- a/etc/redis/values.yaml
+++ b/etc/redis/values.yaml
@@ -1,3 +1,14 @@
+image:
+  repository: bitnamilegacy/redis
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
 ## @section Redis&trade; common configuration parameters
 ## https://github.com/bitnami/bitnami-docker-redis#configuration
 ##
@@ -40,6 +51,8 @@ metrics:
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ##
+  image:
+    repository: bitnamilegacy/redis-exporter
   serviceMonitor:
     ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
     ##
@@ -54,6 +67,8 @@ sysctl:
   enabled: true
   ## @param sysctl.command override default init-sysctl container command (useful when using custom images)
   ##
+  image:
+    repository: bitnamilegacy/os-shell
   command:
     - /bin/sh
     - -c


### PR DESCRIPTION
# Problem
Bitnami has moved supported docker images to a paid license.

# Solution
Legacy docker images (as used by RADAR-base) are still available in the _bitnamilegacy_ repo. This PR will update repository values for internal charts to the new repo.

# Note
Repo for internal (RADAR-base specific) charts will be handled in PR to the radar-helm-charts repo.