### PR TITLE
fix: MacOSX compatibility

### DIFF
--- a/bin/generate-secrets
+++ b/bin/generate-secrets
@@ -12,7 +12,7 @@ fi
 if [ -f etc/secrets.yaml ]; then
   echo "WARN: etc/secrets.yaml file already exists. The existing secrets can be reset."
   echo "Note: for already initialized systems like redis and PostgreSQL changing the secret will not affect the actual password."
-  read -p "Do you wish to reset all passwords? [y/N] " yn
+  read -p "Do you wish to reset all passwords? [y/N] " yn || yn=N
   case $yn in
     [Yy]* ) ;;
     * ) exit;;

--- a/bin/util.sh
+++ b/bin/util.sh
@@ -47,7 +47,7 @@ copy_template_if_absent() {
 
 create_production_yaml() {
   copy_template_if_absent etc/production.yaml etc/base.yaml
-  sed -i "/_chart_version/d" etc/production.yaml
+  sed -i.bak "/_chart_version/d" etc/production.yaml && rm -f etc/production.yaml.bak
 }
 
 # Copies the template (defined by the given config file with suffix

--- a/bin/util.sh
+++ b/bin/util.sh
@@ -47,6 +47,7 @@ copy_template_if_absent() {
 
 create_production_yaml() {
   copy_template_if_absent etc/production.yaml etc/base.yaml
+  # `-i.bak` is portable across GNU sed (Linux) and BSD sed (macOS), which requires an explicit backup-suffix argument for in-place edits. The .bak file is removed after.
   sed -i.bak "/_chart_version/d" etc/production.yaml && rm -f etc/production.yaml.bak
 }
 

--- a/bin/version_scan
+++ b/bin/version_scan
@@ -4,6 +4,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # Initialize a RADAR-base deployment where all components are installed.
 yes | ./bin/init
+# `-i.bak` is portable across GNU sed (Linux) and BSD sed (macOS), which requires an explicit backup-suffix argument for in-place edits. The .bak file is removed after.
 sed -i.bak '/_install: /s/false/true/' etc/production.yaml && rm -f etc/production.yaml.bak
 
 helmfile template | grep -E "helm.sh/chart:|image:|containers:|initContainers:" | uniq | sed -r "s/\s+//g" | sed "s/\"//g" | sed -r "s/^-//g" > /tmp/helmfile.txt

--- a/bin/version_scan
+++ b/bin/version_scan
@@ -4,7 +4,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # Initialize a RADAR-base deployment where all components are installed.
 yes | ./bin/init
-sed -i '/_install: /s/false/true/' etc/production.yaml
+sed -i.bak '/_install: /s/false/true/' etc/production.yaml && rm -f etc/production.yaml.bak
 
 helmfile template | grep -E "helm.sh/chart:|image:|containers:|initContainers:" | uniq | sed -r "s/\s+//g" | sed "s/\"//g" | sed -r "s/^-//g" > /tmp/helmfile.txt
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -38,19 +38,8 @@ The following tools must be installed on your machine before running the steps b
 
 - [yq](https://github.com/mikefarah/yq) — used by `./bin/generate-secrets`. On macOS: `brew install yq`.
 
-The local k3d workflow described below has been verified against the following tool versions. Newer versions are
-likely to work but may not match the cluster-side compatibility matrix listed in the main [README](../README.md);
-fall back to those if you run into issues.
-
-| Tool     | Version                        |
-|----------|--------------------------------|
-| Docker   | 29.2.1                         |
-| k3d      | v5.9.0 (bundles k3s v1.35.5+k3s1) |
-| kubectl  | v1.35.1                        |
-| Helm     | v3.20.0                        |
-| Helmfile | 0.169.1                        |
-| OpenJDK  | 26.0.1                         |
-| yq       | v4.53.3                        |
+For supported versions of the cluster-side tooling (Kubernetes, K3s, kubectl, Helm, Helmfile, yq), see the
+[Software Compatibility](../README.md#software-compatibility) section of the main README.
 
 1. Install k3d (see [here](https://github.com/k3d-io/k3d#get))
 2. Create a k3d cluster that is configured to run RADAR-base:
@@ -84,15 +73,6 @@ k3d cluster create my-test-cluster --config=dev/k3d-dev-containerd.yaml
 - set _kubeContext_ to _k3d-my-test-cluster_
 - set _dev_deployment_ to _true_
 - (optional) enable/disable components as needed with the __install_ fields
-
-   When toggling components, keep in mind these cross-component dependencies. Enabling the consumer without its
-   backing service will leave the consumer pod in `CrashLoopBackOff`:
-
-   | Component | Required dependency |
-   |---|---|
-   | `management_portal` | A PostgreSQL backend. Either `postgresql._install: true` **or** `cloudnative_postgresql._install: true` (the latter also requires `cloudnativepg_operator`). |
-   | `radar_s3_connector` | An S3-compatible object store at the configured `s3Endpoint`. For local development, enable the bundled MinIO with `minio._install: true`. |
-   | `radar_output` | Same as `radar_s3_connector` — needs a reachable S3 endpoint for both `source` and `target`. |
 
 5. Install RADAR-Kubernetes on the k3d cluster:
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -6,6 +6,7 @@
 * [Development Guide](#development-guide)
   * [Table of Contents](#table-of-contents)
   * [Development automation](#development-automation)
+    * [Prerequisites](#prerequisites)
         * [Containerd](#containerd)
   * [Adding a new component to RADAR-Kuberentes](#adding-a-new-component-to-radar-kuberentes)
   * [Testing the changes](#testing-the-changes)
@@ -16,6 +17,40 @@
 
 This repository can be used for development automation for instance on a k3s or k3d (dockerized k3s) cluster. The
 example below shows how to deploy on a k3d cluster.
+
+### Prerequisites
+
+The following tools must be installed on your machine before running the steps below:
+
+- [Docker](https://www.docker.com/products/docker-desktop/) — provides the container runtime for k3d. Allocate enough
+  memory to Docker Desktop (12 GB or more is recommended) so the cluster can fit all the default RADAR-base components.
+- [k3d](https://github.com/k3d-io/k3d#get) — runs k3s in Docker.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) — Kubernetes CLI.
+- [helm](https://helm.sh/docs/intro/install/) and [helmfile](https://github.com/helmfile/helmfile#installation) — chart
+  management used by this repository.
+- A JDK that provides `keytool` — used by `./bin/init` to generate the ManagementPortal keystore. On macOS:
+
+  ```shell
+  brew install openjdk
+  # Homebrew's openjdk is keg-only, so add it to your PATH (zsh shown):
+  echo 'export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc
+  ```
+
+- [yq](https://github.com/mikefarah/yq) — used by `./bin/generate-secrets`. On macOS: `brew install yq`.
+
+The local k3d workflow described below has been verified against the following tool versions. Newer versions are
+likely to work but may not match the cluster-side compatibility matrix listed in the main [README](../README.md);
+fall back to those if you run into issues.
+
+| Tool     | Version                        |
+|----------|--------------------------------|
+| Docker   | 29.2.1                         |
+| k3d      | v5.9.0 (bundles k3s v1.35.5+k3s1) |
+| kubectl  | v1.35.1                        |
+| Helm     | v3.20.0                        |
+| Helmfile | 0.169.1                        |
+| OpenJDK  | 26.0.1                         |
+| yq       | v4.53.3                        |
 
 1. Install k3d (see [here](https://github.com/k3d-io/k3d#get))
 2. Create a k3d cluster that is configured to run RADAR-base:
@@ -50,6 +85,15 @@ k3d cluster create my-test-cluster --config=dev/k3d-dev-containerd.yaml
 - set _dev_deployment_ to _true_
 - (optional) enable/disable components as needed with the __install_ fields
 
+   When toggling components, keep in mind these cross-component dependencies. Enabling the consumer without its
+   backing service will leave the consumer pod in `CrashLoopBackOff`:
+
+   | Component | Required dependency |
+   |---|---|
+   | `management_portal` | A PostgreSQL backend. Either `postgresql._install: true` **or** `cloudnative_postgresql._install: true` (the latter also requires `cloudnativepg_operator`). |
+   | `radar_s3_connector` | An S3-compatible object store at the configured `s3Endpoint`. For local development, enable the bundled MinIO with `minio._install: true`. |
+   | `radar_output` | Same as `radar_s3_connector` — needs a reachable S3 endpoint for both `source` and `target`. |
+
 5. Install RADAR-Kubernetes on the k3d cluster:
 
 ```shell
@@ -57,6 +101,27 @@ helmfile sync
 ```
 
 When installation is complete, you can access the applications at `http://localhost`.
+
+### Stopping and restarting the cluster
+
+The k3d cluster can be stopped to free up host resources without losing state, and started again later. All deployed
+applications, persistent volumes and configuration are preserved across a stop/start cycle.
+
+```shell
+# Stop the cluster (containers are stopped but not removed)
+k3d cluster stop my-test-cluster
+
+# Start the cluster again
+k3d cluster start my-test-cluster
+```
+
+After a restart you may see pods in `Unknown` or transient `CrashLoopBackOff` states for a minute or two while
+dependencies (CoreDNS, Kafka, catalog-server, etc.) come back up. Most pods recover on their own; if one stays stuck,
+delete it and the controller will recreate it, for example:
+
+```shell
+kubectl delete pod <pod-name>
+```
 
 ## Adding a new component to RADAR-Kuberentes
 
@@ -91,6 +156,20 @@ installation faster if you only select your component to install:
 
 ```
 helmfile apply --file helmfile.d/name-of-the-helmfile.yaml --selector name=name-of-the-component
+```
+
+When you are iterating on a single release and just want to apply your `etc/production.yaml` changes for it without
+running a full `helmfile sync`, the selector flag works with `sync` too (and you do not need to point at a specific
+helmfile — helmfile will find the matching release across `helmfile.d/`):
+
+```shell
+helmfile -l name=<release-name> sync
+```
+
+For example, after enabling MinIO in `etc/production.yaml`:
+
+```shell
+helmfile -l name=minio sync
 ```
 
 You can also use other the helmfile commands like `helmfile template` and `helmfile diff` to see what is being applied


### PR DESCRIPTION
Fix `./bin/init` so it runs on macOS and is safe to re-run.                                                                                                             
  - Expand `docs/development_guide.md` with prerequisites, tested tool versions, cluster start/stop commands, component dependency notes, and the single-release helmfile sync command.                                                                                                                                                             
                                                                                                                                                                            
  ## Test plan                                                                                                                                                              
                                                                                                                                                                            
  Verified locally on a k3d cluster (macOS + Docker Desktop). After `./bin/init` and `helmfile sync`, the following components are running:                               
                                                                                                                                                                            
  - catalog-server                                                                                                                                                        
  - cloudnativepg-operator + radar-cloudnative-postgresql-cluster                                                                                                           
  - cp-kafka, cp-schema-registry, cp-zookeeper                                                                                                                            
  - ingress-nginx                                                                                                                                                           
  - management-portal                                                                                                                                                     
  - minio                                                                                                                                                                   
  - radar-gateway
  - radar-home                                                                                                                                                              
  - radar-output                                                                                                                                                          
  - radar-redis-replication (3 replicas)                                                                                                                                    
  - radar-s3-connector       